### PR TITLE
docs(README): update demo prompt recording, use gif in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@
 ## About
 This is an [MCP](https://modelcontextprotocol.io/introduction) server to allow LLMs to interact with a running [Prometheus](https://prometheus.io/) instance via the API to do things like generate and execute promql queries, list and analyze metrics, etc.
 
-Here is a screen recording using Google Gemini models to research and analyze the `prom_mcp_tool_call_duration_seconds` metric, produced by the prometheus-mcp-server itself:
+Here is a screen recording using Google Gemini models to report on the health of the Prometheus instance that powers [prometheus.demo.prometheus.io/](https://prometheus.demo.prometheus.io/query). The prompt used was:
 
-[![asciicast](https://asciinema.org/a/728182.svg)](https://asciinema.org/a/728182)
+> please provide a comprehensive review and summary of the prometheus server.
+> review it's configuration, flags, runtime/build info, and anything else that
+> you feel may provide insight into the status of the prometheus instance,
+> including analyzing metrics and executing queries
+
+[![Demo prompt to review the health of the demo.prometheus.io prometheus instance](images/demo-usage-with-prometheus-demo-server.gif)](https://asciinema.org/a/733513)
 
 ### Tools
 


### PR DESCRIPTION
This updates the demo in the README to a new screen recording that uses
the MCP server and Google Gemini models to review and report on the
status of the prometheus instance powering
https://prometheus.demo.prometheus.io/.

Rather than linking to the video for the README auto play, this now also
includes a gif of the recording for the README.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
