### PR TITLE
feat/tests

### DIFF
--- a/cmd/prometheus-mcp-server/main.go
+++ b/cmd/prometheus-mcp-server/main.go
@@ -104,12 +104,13 @@ func main() {
 		logger.Error("Failed to load HTTP config file, using default HTTP round tripper", "err", err)
 	}
 
-	if err := mcp.NewAPIClient(*flagPrometheusUrl, rt); err != nil {
+	ctx := context.Background()
+	client, err := mcp.NewAPIClient(*flagPrometheusUrl, rt)
+	if err != nil {
 		logger.Error("Failed to create Prometheus client for MCP server", "err", err)
 	}
 
-	ctx := context.Background()
-	mcpServer := mcp.NewServer(logger, *flagEnableTsdbAdminTools)
+	mcpServer := mcp.NewServer(logger, client, *flagEnableTsdbAdminTools)
 	srv := setupServer(logger)
 
 	var g run.Group

--- a/cmd/prometheus-mcp-server/main.go
+++ b/cmd/prometheus-mcp-server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/promslog/flag"
 	"github.com/prometheus/exporter-toolkit/web"
@@ -97,7 +98,13 @@ func main() {
 	logger := promslog.New(promslogConfig)
 	logger.Info("Starting "+programName, "version", version.Version, "build_date", version.BuildDate, "commit", version.Commit, "go_version", runtime.Version())
 
-	if err := mcp.NewAPIClient(*flagPrometheusUrl, *flagHttpConfig); err != nil {
+	// Optionally load HTTP config file to configure HTTP client for Prometheus API.
+	rt, err := getRoundTripperFromConfig(*flagHttpConfig)
+	if err != nil {
+		logger.Error("Failed to load HTTP config file, using default HTTP round tripper", "err", err)
+	}
+
+	if err := mcp.NewAPIClient(*flagPrometheusUrl, rt); err != nil {
 		logger.Error("Failed to create Prometheus client for MCP server", "err", err)
 	}
 
@@ -244,4 +251,30 @@ func setupServer(logger *slog.Logger) *http.Server {
 	}
 
 	return server
+}
+
+func getRoundTripperFromConfig(httpConfig string) (http.RoundTripper, error) {
+	httpClient := http.DefaultClient
+	if httpConfig != "" {
+		httpCfg, _, err := config_util.LoadHTTPConfigFile(httpConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load HTTP configuration file %s: %w", httpConfig, err)
+		}
+
+		if err = httpCfg.Validate(); err != nil {
+			return nil, fmt.Errorf("failed to validate HTTP configuration file %s: %w", httpConfig, err)
+		}
+
+		httpClient, err = config_util.NewClientFromConfig(*httpCfg, "prometheus-mcp-server")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP client from configuration file %s: %w", httpConfig, err)
+		}
+	}
+
+	rt := http.DefaultTransport
+	if httpClient.Transport != nil {
+		rt = httpClient.Transport
+	}
+
+	return rt, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/common v0.65.0
 	github.com/prometheus/exporter-toolkit v0.14.0
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
@@ -18,6 +19,7 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/spf13/cast v1.9.2 // indirect

--- a/pkg/mcp/api_mock_test.go
+++ b/pkg/mcp/api_mock_test.go
@@ -1,0 +1,164 @@
+package mcp
+
+import (
+	"context"
+	"time"
+
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+var _ promv1.API = (*MockPrometheusAPI)(nil)
+
+// MockPrometheusAPI is a mock implementation of the promv1.API interface.
+type MockPrometheusAPI struct {
+	AlertManagersFunc   func(ctx context.Context) (promv1.AlertManagersResult, error)
+	AlertsFunc          func(ctx context.Context) (promv1.AlertsResult, error)
+	BuildinfoFunc       func(ctx context.Context) (promv1.BuildinfoResult, error)
+	ConfigFunc          func(ctx context.Context) (promv1.ConfigResult, error)
+	CleanTombstonesFunc func(ctx context.Context) error
+	DeleteSeriesFunc    func(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error
+	FlagsFunc           func(ctx context.Context) (promv1.FlagsResult, error)
+	LabelNamesFunc      func(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...promv1.Option) ([]string, promv1.Warnings, error)
+	LabelValuesFunc     func(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time, opts ...promv1.Option) (model.LabelValues, promv1.Warnings, error)
+	MetadataFunc        func(ctx context.Context, metric string, limit string) (map[string][]promv1.Metadata, error)
+	QueryFunc           func(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error)
+	QueryExemplarsFunc  func(ctx context.Context, query string, startTime time.Time, endTime time.Time) ([]promv1.ExemplarQueryResult, error)
+	QueryRangeFunc      func(ctx context.Context, query string, r promv1.Range, opts ...promv1.Option) (model.Value, promv1.Warnings, error)
+	RulesFunc           func(ctx context.Context) (promv1.RulesResult, error)
+	RuntimeinfoFunc     func(ctx context.Context) (promv1.RuntimeinfoResult, error)
+	SeriesFunc          func(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...promv1.Option) ([]model.LabelSet, promv1.Warnings, error)
+	SnapshotFunc        func(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error)
+	TargetsFunc         func(ctx context.Context) (promv1.TargetsResult, error)
+	TargetsMetadataFunc func(ctx context.Context, matchTarget string, metric string, limit string) ([]promv1.MetricMetadata, error)
+	TSDBFunc            func(ctx context.Context, opts ...promv1.Option) (promv1.TSDBResult, error)
+	WalReplayFunc       func(ctx context.Context) (promv1.WalReplayStatus, error)
+}
+
+// Implement all methods of promv1.API to delegate to the function fields.
+func (m *MockPrometheusAPI) AlertManagers(ctx context.Context) (promv1.AlertManagersResult, error) {
+	if m.AlertManagersFunc != nil {
+		return m.AlertManagersFunc(ctx)
+	}
+	return promv1.AlertManagersResult{}, nil
+}
+func (m *MockPrometheusAPI) Alerts(ctx context.Context) (promv1.AlertsResult, error) {
+	if m.AlertsFunc != nil {
+		return m.AlertsFunc(ctx)
+	}
+	return promv1.AlertsResult{}, nil
+}
+func (m *MockPrometheusAPI) Buildinfo(ctx context.Context) (promv1.BuildinfoResult, error) {
+	if m.BuildinfoFunc != nil {
+		return m.BuildinfoFunc(ctx)
+	}
+	return promv1.BuildinfoResult{}, nil
+}
+func (m *MockPrometheusAPI) Config(ctx context.Context) (promv1.ConfigResult, error) {
+	if m.ConfigFunc != nil {
+		return m.ConfigFunc(ctx)
+	}
+	return promv1.ConfigResult{}, nil
+}
+func (m *MockPrometheusAPI) CleanTombstones(ctx context.Context) error {
+	if m.CleanTombstonesFunc != nil {
+		return m.CleanTombstonesFunc(ctx)
+	}
+	return nil
+}
+func (m *MockPrometheusAPI) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+	if m.DeleteSeriesFunc != nil {
+		return m.DeleteSeriesFunc(ctx, matches, startTime, endTime)
+	}
+	return nil
+}
+func (m *MockPrometheusAPI) Flags(ctx context.Context) (promv1.FlagsResult, error) {
+	if m.FlagsFunc != nil {
+		return m.FlagsFunc(ctx)
+	}
+	return promv1.FlagsResult{}, nil
+}
+func (m *MockPrometheusAPI) LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...promv1.Option) ([]string, promv1.Warnings, error) {
+	if m.LabelNamesFunc != nil {
+		return m.LabelNamesFunc(ctx, matches, startTime, endTime, opts...)
+	}
+	return nil, nil, nil
+}
+func (m *MockPrometheusAPI) LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time, opts ...promv1.Option) (model.LabelValues, promv1.Warnings, error) {
+	if m.LabelValuesFunc != nil {
+		return m.LabelValuesFunc(ctx, label, matches, startTime, endTime, opts...)
+	}
+	return nil, nil, nil
+}
+func (m *MockPrometheusAPI) Metadata(ctx context.Context, metric string, limit string) (map[string][]promv1.Metadata, error) {
+	if m.MetadataFunc != nil {
+		return m.MetadataFunc(ctx, metric, limit)
+	}
+	return nil, nil
+}
+func (m *MockPrometheusAPI) Query(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+	if m.QueryFunc != nil {
+		return m.QueryFunc(ctx, query, ts, opts...)
+	}
+	return nil, nil, nil
+}
+func (m *MockPrometheusAPI) QueryExemplars(ctx context.Context, query string, startTime time.Time, endTime time.Time) ([]promv1.ExemplarQueryResult, error) {
+	if m.QueryExemplarsFunc != nil {
+		return m.QueryExemplarsFunc(ctx, query, startTime, endTime)
+	}
+	return nil, nil
+}
+func (m *MockPrometheusAPI) QueryRange(ctx context.Context, query string, r promv1.Range, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+	if m.QueryRangeFunc != nil {
+		return m.QueryRangeFunc(ctx, query, r, opts...)
+	}
+	return nil, nil, nil
+}
+func (m *MockPrometheusAPI) Rules(ctx context.Context) (promv1.RulesResult, error) {
+	if m.RulesFunc != nil {
+		return m.RulesFunc(ctx)
+	}
+	return promv1.RulesResult{}, nil
+}
+func (m *MockPrometheusAPI) Runtimeinfo(ctx context.Context) (promv1.RuntimeinfoResult, error) {
+	if m.RuntimeinfoFunc != nil {
+		return m.RuntimeinfoFunc(ctx)
+	}
+	return promv1.RuntimeinfoResult{}, nil
+}
+func (m *MockPrometheusAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...promv1.Option) ([]model.LabelSet, promv1.Warnings, error) {
+	if m.SeriesFunc != nil {
+		return m.SeriesFunc(ctx, matches, startTime, endTime, opts...)
+	}
+	return nil, nil, nil
+}
+func (m *MockPrometheusAPI) Snapshot(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error) {
+	if m.SnapshotFunc != nil {
+		return m.SnapshotFunc(ctx, skipHead)
+	}
+	return promv1.SnapshotResult{}, nil
+}
+func (m *MockPrometheusAPI) Targets(ctx context.Context) (promv1.TargetsResult, error) {
+	if m.TargetsFunc != nil {
+		return m.TargetsFunc(ctx)
+	}
+	return promv1.TargetsResult{}, nil
+}
+func (m *MockPrometheusAPI) TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]promv1.MetricMetadata, error) {
+	if m.TargetsMetadataFunc != nil {
+		return m.TargetsMetadataFunc(ctx, matchTarget, metric, limit)
+	}
+	return nil, nil
+}
+func (m *MockPrometheusAPI) TSDB(ctx context.Context, opts ...promv1.Option) (promv1.TSDBResult, error) {
+	if m.TSDBFunc != nil {
+		return m.TSDBFunc(ctx, opts...)
+	}
+	return promv1.TSDBResult{}, nil
+}
+func (m *MockPrometheusAPI) WalReplay(ctx context.Context) (promv1.WalReplayStatus, error) {
+	if m.WalReplayFunc != nil {
+		return m.WalReplayFunc(ctx)
+	}
+	return promv1.WalReplayStatus{}, nil
+}

--- a/pkg/mcp/promapi.go
+++ b/pkg/mcp/promapi.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -57,13 +58,21 @@ func NewAPIClient(prometheusUrl string, rt http.RoundTripper) (promv1.API, error
 	return client, nil
 }
 
-func getApiClientFromContext(ctx context.Context) promv1.API {
-	client, _ := ctx.Value(apiClientKey{}).(promv1.API)
-	return client
+func getApiClientFromContext(ctx context.Context) (promv1.API, error) {
+	client, ok := ctx.Value(apiClientKey{}).(promv1.API)
+	if !ok {
+		return nil, errors.New("failed to get prometheus API client from context")
+
+	}
+
+	return client, nil
 }
 
 func alertmanagersApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -85,7 +94,10 @@ func alertmanagersApiCall(ctx context.Context) (string, error) {
 }
 
 func flagsApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -107,7 +119,10 @@ func flagsApiCall(ctx context.Context) (string, error) {
 }
 
 func listAlertsApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -129,7 +144,10 @@ func listAlertsApiCall(ctx context.Context) (string, error) {
 }
 
 func tsdbStatsApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -156,7 +174,10 @@ type queryApiResponse struct {
 }
 
 func queryApiCall(ctx context.Context, query string, ts time.Time) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -183,7 +204,10 @@ func queryApiCall(ctx context.Context, query string, ts time.Time) (string, erro
 }
 
 func rangeQueryApiCall(ctx context.Context, query string, start, end time.Time, step time.Duration) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -210,7 +234,10 @@ func rangeQueryApiCall(ctx context.Context, query string, start, end time.Time, 
 }
 
 func exemplarQueryApiCall(ctx context.Context, query string, start, end time.Time) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -232,7 +259,10 @@ func exemplarQueryApiCall(ctx context.Context, query string, start, end time.Tim
 }
 
 func seriesApiCall(ctx context.Context, matches []string, start, end time.Time) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -265,7 +295,10 @@ func seriesApiCall(ctx context.Context, matches []string, start, end time.Time) 
 }
 
 func labelNamesApiCall(ctx context.Context, matches []string, start, end time.Time) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -292,7 +325,10 @@ func labelNamesApiCall(ctx context.Context, matches []string, start, end time.Ti
 }
 
 func labelValuesApiCall(ctx context.Context, label string, matches []string, start, end time.Time) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -324,7 +360,10 @@ func labelValuesApiCall(ctx context.Context, label string, matches []string, sta
 }
 
 func buildinfoApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -346,7 +385,10 @@ func buildinfoApiCall(ctx context.Context) (string, error) {
 }
 
 func configApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -368,7 +410,10 @@ func configApiCall(ctx context.Context) (string, error) {
 }
 
 func runtimeinfoApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -390,7 +435,10 @@ func runtimeinfoApiCall(ctx context.Context) (string, error) {
 }
 
 func rulesApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -412,7 +460,10 @@ func rulesApiCall(ctx context.Context) (string, error) {
 }
 
 func targetsApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -434,7 +485,10 @@ func targetsApiCall(ctx context.Context) (string, error) {
 }
 
 func targetsMetadataApiCall(ctx context.Context, matchTarget, metric, limit string) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -456,7 +510,10 @@ func targetsMetadataApiCall(ctx context.Context, matchTarget, metric, limit stri
 }
 
 func metricMetadataApiCall(ctx context.Context, metric, limit string) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -478,7 +535,10 @@ func metricMetadataApiCall(ctx context.Context, metric, limit string) (string, e
 }
 
 func walReplayApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
@@ -500,13 +560,16 @@ func walReplayApiCall(ctx context.Context) (string, error) {
 }
 
 func cleanTombstonesApiCall(ctx context.Context) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/admin/tsdb/clean_tombstones"
 	startTs := time.Now()
-	err := client.CleanTombstones(ctx)
+	err = client.CleanTombstones(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -517,13 +580,16 @@ func cleanTombstonesApiCall(ctx context.Context) (string, error) {
 }
 
 func deleteSeriesApiCall(ctx context.Context, matches []string, start, end time.Time) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/admin/tsdb/delete_series"
 	startTs := time.Now()
-	err := client.DeleteSeries(ctx, matches, start, end)
+	err = client.DeleteSeries(ctx, matches, start, end)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -534,7 +600,10 @@ func deleteSeriesApiCall(ctx context.Context, matches []string, start, end time.
 }
 
 func snapshotApiCall(ctx context.Context, skipHead bool) (string, error) {
-	client := getApiClientFromContext(ctx)
+	client, err := getApiClientFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting API client from context: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 

--- a/pkg/mcp/promapi.go
+++ b/pkg/mcp/promapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -49,8 +50,8 @@ func init() {
 }
 
 // NewAPIClient creates a new prometheus v1 API client for use by the MCP server
-func NewAPIClient(prometheusUrl, httpConfig string) error {
-	client, err := mcpProm.NewAPIClient(prometheusUrl, httpConfig)
+func NewAPIClient(prometheusUrl string, rt http.RoundTripper) error {
+	client, err := mcpProm.NewAPIClient(prometheusUrl, rt)
 	if err != nil {
 		return fmt.Errorf("failed to create prometheus API client: %w", err)
 	}

--- a/pkg/mcp/promapi.go
+++ b/pkg/mcp/promapi.go
@@ -18,8 +18,6 @@ import (
 var (
 	DefaultLookbackDelta = -5 * time.Minute
 
-	// package local Prometheus API client for use with mcp tools/resources/etc
-	apiV1Client  promv1.API
 	apiTimeout   = 1 * time.Minute
 	queryTimeout = 30 * time.Second
 
@@ -50,23 +48,28 @@ func init() {
 }
 
 // NewAPIClient creates a new prometheus v1 API client for use by the MCP server
-func NewAPIClient(prometheusUrl string, rt http.RoundTripper) error {
+func NewAPIClient(prometheusUrl string, rt http.RoundTripper) (promv1.API, error) {
 	client, err := mcpProm.NewAPIClient(prometheusUrl, rt)
 	if err != nil {
-		return fmt.Errorf("failed to create prometheus API client: %w", err)
+		return nil, fmt.Errorf("failed to create prometheus API client: %w", err)
 	}
 
-	apiV1Client = client
-	return nil
+	return client, nil
+}
+
+func getApiClientFromContext(ctx context.Context) promv1.API {
+	client, _ := ctx.Value(apiClientKey{}).(promv1.API)
+	return client
 }
 
 func alertmanagersApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/alertmanagers"
 	startTs := time.Now()
-	ams, err := apiV1Client.AlertManagers(ctx)
+	ams, err := client.AlertManagers(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -82,12 +85,13 @@ func alertmanagersApiCall(ctx context.Context) (string, error) {
 }
 
 func flagsApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/status/flags"
 	startTs := time.Now()
-	flags, err := apiV1Client.Flags(ctx)
+	flags, err := client.Flags(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -103,12 +107,13 @@ func flagsApiCall(ctx context.Context) (string, error) {
 }
 
 func listAlertsApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/alerts"
 	startTs := time.Now()
-	alerts, err := apiV1Client.Alerts(ctx)
+	alerts, err := client.Alerts(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -124,12 +129,13 @@ func listAlertsApiCall(ctx context.Context) (string, error) {
 }
 
 func tsdbStatsApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/status/tsdb"
 	startTs := time.Now()
-	tsdbStats, err := apiV1Client.TSDB(ctx)
+	tsdbStats, err := client.TSDB(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -150,12 +156,13 @@ type queryApiResponse struct {
 }
 
 func queryApiCall(ctx context.Context, query string, ts time.Time) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/query"
 	startTs := time.Now()
-	result, warnings, err := apiV1Client.Query(ctx, query, ts, promv1.WithTimeout(queryTimeout))
+	result, warnings, err := client.Query(ctx, query, ts, promv1.WithTimeout(queryTimeout))
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -176,12 +183,13 @@ func queryApiCall(ctx context.Context, query string, ts time.Time) (string, erro
 }
 
 func rangeQueryApiCall(ctx context.Context, query string, start, end time.Time, step time.Duration) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/query_range"
 	startTs := time.Now()
-	result, warnings, err := apiV1Client.QueryRange(ctx, query, promv1.Range{Start: start, End: end, Step: step})
+	result, warnings, err := client.QueryRange(ctx, query, promv1.Range{Start: start, End: end, Step: step})
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -202,12 +210,13 @@ func rangeQueryApiCall(ctx context.Context, query string, start, end time.Time, 
 }
 
 func exemplarQueryApiCall(ctx context.Context, query string, start, end time.Time) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/query_exemplars"
 	startTs := time.Now()
-	res, err := apiV1Client.QueryExemplars(ctx, query, start, end)
+	res, err := client.QueryExemplars(ctx, query, start, end)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -223,12 +232,13 @@ func exemplarQueryApiCall(ctx context.Context, query string, start, end time.Tim
 }
 
 func seriesApiCall(ctx context.Context, matches []string, start, end time.Time) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/series"
 	startTs := time.Now()
-	result, warnings, err := apiV1Client.Series(ctx, matches, start, end)
+	result, warnings, err := client.Series(ctx, matches, start, end)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -255,12 +265,13 @@ func seriesApiCall(ctx context.Context, matches []string, start, end time.Time) 
 }
 
 func labelNamesApiCall(ctx context.Context, matches []string, start, end time.Time) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/labels"
 	startTs := time.Now()
-	result, warnings, err := apiV1Client.LabelNames(ctx, matches, start, end)
+	result, warnings, err := client.LabelNames(ctx, matches, start, end)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -281,12 +292,13 @@ func labelNamesApiCall(ctx context.Context, matches []string, start, end time.Ti
 }
 
 func labelValuesApiCall(ctx context.Context, label string, matches []string, start, end time.Time) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/label/:name/values"
 	startTs := time.Now()
-	result, warnings, err := apiV1Client.LabelValues(ctx, label, matches, start, end)
+	result, warnings, err := client.LabelValues(ctx, label, matches, start, end)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -312,12 +324,13 @@ func labelValuesApiCall(ctx context.Context, label string, matches []string, sta
 }
 
 func buildinfoApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/status/buildinfo"
 	startTs := time.Now()
-	bi, err := apiV1Client.Buildinfo(ctx)
+	bi, err := client.Buildinfo(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -333,12 +346,13 @@ func buildinfoApiCall(ctx context.Context) (string, error) {
 }
 
 func configApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/status/config"
 	startTs := time.Now()
-	cfg, err := apiV1Client.Config(ctx)
+	cfg, err := client.Config(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -354,12 +368,13 @@ func configApiCall(ctx context.Context) (string, error) {
 }
 
 func runtimeinfoApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/status/runtimeinfo"
 	startTs := time.Now()
-	ri, err := apiV1Client.Runtimeinfo(ctx)
+	ri, err := client.Runtimeinfo(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -375,12 +390,13 @@ func runtimeinfoApiCall(ctx context.Context) (string, error) {
 }
 
 func rulesApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/rules"
 	startTs := time.Now()
-	rules, err := apiV1Client.Rules(ctx)
+	rules, err := client.Rules(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -396,12 +412,13 @@ func rulesApiCall(ctx context.Context) (string, error) {
 }
 
 func targetsApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/targets"
 	startTs := time.Now()
-	targets, err := apiV1Client.Targets(ctx)
+	targets, err := client.Targets(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -417,12 +434,13 @@ func targetsApiCall(ctx context.Context) (string, error) {
 }
 
 func targetsMetadataApiCall(ctx context.Context, matchTarget, metric, limit string) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/targets/metadata"
 	startTs := time.Now()
-	tm, err := apiV1Client.TargetsMetadata(ctx, matchTarget, metric, limit)
+	tm, err := client.TargetsMetadata(ctx, matchTarget, metric, limit)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -438,12 +456,13 @@ func targetsMetadataApiCall(ctx context.Context, matchTarget, metric, limit stri
 }
 
 func metricMetadataApiCall(ctx context.Context, metric, limit string) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/metadata"
 	startTs := time.Now()
-	mm, err := apiV1Client.Metadata(ctx, metric, limit)
+	mm, err := client.Metadata(ctx, metric, limit)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -459,12 +478,13 @@ func metricMetadataApiCall(ctx context.Context, metric, limit string) (string, e
 }
 
 func walReplayApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/status/walreplay"
 	startTs := time.Now()
-	wal, err := apiV1Client.WalReplay(ctx)
+	wal, err := client.WalReplay(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -480,12 +500,13 @@ func walReplayApiCall(ctx context.Context) (string, error) {
 }
 
 func cleanTombstonesApiCall(ctx context.Context) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/admin/tsdb/clean_tombstones"
 	startTs := time.Now()
-	err := apiV1Client.CleanTombstones(ctx)
+	err := client.CleanTombstones(ctx)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -496,12 +517,13 @@ func cleanTombstonesApiCall(ctx context.Context) (string, error) {
 }
 
 func deleteSeriesApiCall(ctx context.Context, matches []string, start, end time.Time) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/admin/tsdb/delete_series"
 	startTs := time.Now()
-	err := apiV1Client.DeleteSeries(ctx, matches, start, end)
+	err := client.DeleteSeries(ctx, matches, start, end)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
@@ -512,12 +534,13 @@ func deleteSeriesApiCall(ctx context.Context, matches []string, start, end time.
 }
 
 func snapshotApiCall(ctx context.Context, skipHead bool) (string, error) {
+	client := getApiClientFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
 
 	path := "/api/v1/admin/tsdb/snapshot"
 	startTs := time.Now()
-	ss, err := apiV1Client.Snapshot(ctx, skipHead)
+	ss, err := client.Snapshot(ctx, skipHead)
 	metricApiCallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricApiCallsFailed.With(prometheus.Labels{"target_path": path}).Inc()

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1026,3 +1026,69 @@ func TestBuildinfoToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestFlagsToolHandler(t *testing.T) {
+	testCases := []struct {
+		name           string
+		request        mcp.CallToolRequest
+		mockFlagsFunc  func(ctx context.Context) (promv1.FlagsResult, error)
+		validateResult func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "flags",
+				},
+			},
+			mockFlagsFunc: func(ctx context.Context) (promv1.FlagsResult, error) {
+				return promv1.FlagsResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "flags",
+				},
+			},
+			mockFlagsFunc: func(ctx context.Context) (promv1.FlagsResult, error) {
+				return promv1.FlagsResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(flagsTool, flagsToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.FlagsFunc = tc.mockFlagsFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -696,3 +696,69 @@ func TestTargetsMetadataToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestListTargetsToolHandler(t *testing.T) {
+	testCases := []struct {
+		name            string
+		request         mcp.CallToolRequest
+		mockTargetsFunc func(ctx context.Context) (promv1.TargetsResult, error)
+		validateResult  func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "list_targets",
+				},
+			},
+			mockTargetsFunc: func(ctx context.Context) (promv1.TargetsResult, error) {
+				return promv1.TargetsResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "list_targets",
+				},
+			},
+			mockTargetsFunc: func(ctx context.Context) (promv1.TargetsResult, error) {
+				return promv1.TargetsResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(targetsTool, targetsToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.TargetsFunc = tc.mockTargetsFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -606,3 +606,93 @@ func TestMetricMetadataToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestTargetsMetadataToolHandler(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		request                 mcp.CallToolRequest
+		mockTargetsMetadataFunc func(ctx context.Context, matchTarget string, metric string, limit string) ([]promv1.MetricMetadata, error)
+		validateResult          func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success with params",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "targets_metadata",
+					Arguments: map[string]any{
+						"match_target": `{job="prometheus"}`,
+						"metric":       "go_goroutines",
+						"limit":        "10",
+					},
+				},
+			},
+			mockTargetsMetadataFunc: func(ctx context.Context, matchTarget string, metric string, limit string) ([]promv1.MetricMetadata, error) {
+				require.Equal(t, `{job="prometheus"}`, matchTarget)
+				require.Equal(t, "go_goroutines", metric)
+				require.Equal(t, "10", limit)
+				return []promv1.MetricMetadata{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "success no params",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "targets_metadata",
+				},
+			},
+			mockTargetsMetadataFunc: func(ctx context.Context, matchTarget string, metric string, limit string) ([]promv1.MetricMetadata, error) {
+				return []promv1.MetricMetadata{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "targets_metadata",
+				},
+			},
+			mockTargetsMetadataFunc: func(ctx context.Context, matchTarget string, metric string, limit string) ([]promv1.MetricMetadata, error) {
+				return nil, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(targetsMetadataTool, targetsMetadataToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.TargetsMetadataFunc = tc.mockTargetsMetadataFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1092,3 +1092,69 @@ func TestFlagsToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestListAlertsToolHandler(t *testing.T) {
+	testCases := []struct {
+		name           string
+		request        mcp.CallToolRequest
+		mockAlertsFunc func(ctx context.Context) (promv1.AlertsResult, error)
+		validateResult func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "list_alerts",
+				},
+			},
+			mockAlertsFunc: func(ctx context.Context) (promv1.AlertsResult, error) {
+				return promv1.AlertsResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "list_alerts",
+				},
+			},
+			mockAlertsFunc: func(ctx context.Context) (promv1.AlertsResult, error) {
+				return promv1.AlertsResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(listAlertsTool, listAlertsToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.AlertsFunc = tc.mockAlertsFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -828,3 +828,69 @@ func TestListRulesToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeinfoToolHandler(t *testing.T) {
+	testCases := []struct {
+		name                string
+		request             mcp.CallToolRequest
+		mockRuntimeinfoFunc func(ctx context.Context) (promv1.RuntimeinfoResult, error)
+		validateResult      func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "runtime_info",
+				},
+			},
+			mockRuntimeinfoFunc: func(ctx context.Context) (promv1.RuntimeinfoResult, error) {
+				return promv1.RuntimeinfoResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "runtime_info",
+				},
+			},
+			mockRuntimeinfoFunc: func(ctx context.Context) (promv1.RuntimeinfoResult, error) {
+				return promv1.RuntimeinfoResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(runtimeinfoTool, runtimeinfoToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.RuntimeinfoFunc = tc.mockRuntimeinfoFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -452,3 +452,69 @@ func TestDeleteSeriesToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanTombstonesToolHandler(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		request                 mcp.CallToolRequest
+		mockCleanTombstonesFunc func(ctx context.Context) error
+		validateResult          func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "clean_tombstones",
+				},
+			},
+			mockCleanTombstonesFunc: func(ctx context.Context) error {
+				return nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "clean_tombstones",
+				},
+			},
+			mockCleanTombstonesFunc: func(ctx context.Context) error {
+				return errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(cleanTombstonesTool, cleanTombstonesToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.CleanTombstonesFunc = tc.mockCleanTombstonesFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -960,3 +960,69 @@ func TestConfigToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildinfoToolHandler(t *testing.T) {
+	testCases := []struct {
+		name              string
+		request           mcp.CallToolRequest
+		mockBuildinfoFunc func(ctx context.Context) (promv1.BuildinfoResult, error)
+		validateResult    func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "build_info",
+				},
+			},
+			mockBuildinfoFunc: func(ctx context.Context) (promv1.BuildinfoResult, error) {
+				return promv1.BuildinfoResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "build_info",
+				},
+			},
+			mockBuildinfoFunc: func(ctx context.Context) (promv1.BuildinfoResult, error) {
+				return promv1.BuildinfoResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(buildinfoTool, buildinfoToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.BuildinfoFunc = tc.mockBuildinfoFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -518,3 +518,91 @@ func TestCleanTombstonesToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestMetricMetadataToolHandler(t *testing.T) {
+	testCases := []struct {
+		name             string
+		request          mcp.CallToolRequest
+		mockMetadataFunc func(ctx context.Context, metric string, limit string) (map[string][]promv1.Metadata, error)
+		validateResult   func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success with params",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "metric_metadata",
+					Arguments: map[string]any{
+						"metric": "go_goroutines",
+						"limit":  "10",
+					},
+				},
+			},
+			mockMetadataFunc: func(ctx context.Context, metric string, limit string) (map[string][]promv1.Metadata, error) {
+				require.Equal(t, "go_goroutines", metric)
+				require.Equal(t, "10", limit)
+				return map[string][]promv1.Metadata{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "success no params",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "metric_metadata",
+				},
+			},
+			mockMetadataFunc: func(ctx context.Context, metric string, limit string) (map[string][]promv1.Metadata, error) {
+				return map[string][]promv1.Metadata{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "metric_metadata",
+				},
+			},
+			mockMetadataFunc: func(ctx context.Context, metric string, limit string) (map[string][]promv1.Metadata, error) {
+				return nil, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(metricMetadataTool, metricMetadataToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.MetadataFunc = tc.mockMetadataFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -762,3 +762,69 @@ func TestListTargetsToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestListRulesToolHandler(t *testing.T) {
+	testCases := []struct {
+		name           string
+		request        mcp.CallToolRequest
+		mockRulesFunc  func(ctx context.Context) (promv1.RulesResult, error)
+		validateResult func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "list_rules",
+				},
+			},
+			mockRulesFunc: func(ctx context.Context) (promv1.RulesResult, error) {
+				return promv1.RulesResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "list_rules",
+				},
+			},
+			mockRulesFunc: func(ctx context.Context) (promv1.RulesResult, error) {
+				return promv1.RulesResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(rulesTool, rulesToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.RulesFunc = tc.mockRulesFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -264,3 +264,73 @@ func TestRangeQueryToolHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestSnapshotToolHandler(t *testing.T) {
+	testCases := []struct {
+		name             string
+		request          mcp.CallToolRequest
+		mockSnapshotFunc func(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error)
+		validateResult   func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "snapshot",
+					Arguments: map[string]any{
+						"skip_head": true,
+					},
+				},
+			},
+			mockSnapshotFunc: func(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error) {
+				require.True(t, skipHead)
+				return promv1.SnapshotResult{}, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "snapshot",
+				},
+			},
+			mockSnapshotFunc: func(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error) {
+				return promv1.SnapshotResult{}, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(snapshotTool, snapshotToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.SnapshotFunc = tc.mockSnapshotFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1,0 +1,133 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/mcptest"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func toolCallResultAsString(result *mcp.CallToolResult) string {
+	var output strings.Builder
+	for _, c := range result.Content {
+		if text, ok := c.(mcp.TextContent); ok {
+			output.WriteString(text.Text)
+		}
+	}
+
+	return output.String()
+}
+
+func TestQueryToolHandler(t *testing.T) {
+	testCases := []struct {
+		name           string
+		request        mcp.CallToolRequest
+		mockQueryFunc  func(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error)
+		validateResult func(t *testing.T, result *mcp.CallToolResult, err error)
+	}{
+		{
+			name: "success",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name: "query",
+					Arguments: map[string]any{
+						"query":     "vector(1)",
+						"timestamp": "1756143048",
+					},
+				},
+			},
+			mockQueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+				require.Equal(t, "vector(1)", query)
+				return model.Vector{&model.Sample{
+					Metric:    model.Metric{},
+					Value:     model.SampleValue(1),
+					Timestamp: model.TimeFromUnix(ts.Unix()),
+				}}, nil, nil
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+				require.Equal(t, `{"result":"{} =\u003e 1 @[1756143048]","warnings":null}`, toolCallResultAsString(result))
+			},
+		},
+		{
+			name: "missing query",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name:      "query",
+					Arguments: map[string]any{},
+				},
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "query must be a string")
+			},
+		},
+		{
+			name: "API error",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name:      "query",
+					Arguments: map[string]any{"query": "up"},
+				},
+			},
+			mockQueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+				return nil, nil, errors.New("prometheus exploded")
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "prometheus exploded")
+			},
+		},
+		{
+			name: "invalid timestamp",
+			request: mcp.CallToolRequest{
+				Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+				Params: mcp.CallToolParams{
+					Name:      "query",
+					Arguments: map[string]any{"query": "up", "timestamp": "not-a-real-timestamp"},
+				},
+			},
+			validateResult: func(t *testing.T, result *mcp.CallToolResult, err error) {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				require.Contains(t, toolCallResultAsString(result), "failed to get ts from args")
+			},
+		},
+	}
+
+	mockAPI := &MockPrometheusAPI{}
+	mockServer := mcptest.NewUnstartedServer(t)
+	mockServer.AddTool(queryTool, queryToolHandler)
+
+	ctx := context.WithValue(context.Background(), apiClientKey{}, mockAPI)
+	err := mockServer.Start(ctx)
+	require.NoError(t, err)
+	defer mockServer.Close()
+
+	mcpClient := mockServer.Client()
+	defer mcpClient.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI.QueryFunc = tc.mockQueryFunc
+
+			res, err := mcpClient.CallTool(ctx, tc.request)
+			require.NoError(t, err)
+
+			tc.validateResult(t, res, err)
+		})
+	}
+}

--- a/pkg/prometheus/api_test.go
+++ b/pkg/prometheus/api_test.go
@@ -1,0 +1,58 @@
+package prometheus
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPrometheusUrl = "https://prometheus.demo.prometheus.io:443/"
+)
+
+// MockRoundTripper is a mock implementation of http.RoundTripper for testing.
+type MockRoundTripper struct {
+	RoundTripFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.RoundTripFunc != nil {
+		return m.RoundTripFunc(req)
+	}
+	return &http.Response{}, nil
+}
+
+func TestNewAPIClient(t *testing.T) {
+	testCases := []struct {
+		name          string
+		prometheusUrl string
+		rt            http.RoundTripper
+		expectedError bool
+	}{
+		{
+			name:          "success",
+			prometheusUrl: testPrometheusUrl,
+			rt:            http.DefaultTransport,
+			expectedError: false,
+		},
+
+		{
+			name:          "with custom roundtripper",
+			prometheusUrl: testPrometheusUrl,
+			rt:            &MockRoundTripper{},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAPIClient(tc.prometheusUrl, tc.rt)
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/prometheus/utils.go
+++ b/pkg/prometheus/utils.go
@@ -7,29 +7,56 @@ import (
 	"time"
 )
 
+var (
+	// Values here are copied and un-exported from Prometheus codebase:
+	// https://github.com/prometheus/prometheus/blob/main/web/api/v1/api.go#L884-L905
+
+	// minTime is the default timestamp used for the start of optional time ranges.
+	// Exposed to let downstream projects reference it.
+	//
+	// Historical note: This should just be time.Unix(math.MinInt64/1000, 0).UTC(),
+	// but it was set to a higher value in the past due to a misunderstanding.
+	// The value is still low enough for practical purposes, so we don't want
+	// to change it now, avoiding confusion for importers of this variable.
+	minTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
+
+	// maxTime is the default timestamp used for the end of optional time ranges.
+	// Exposed to let downstream projects to reference it.
+	//
+	// Historical note: This should just be time.Unix(math.MaxInt64/1000, 0).UTC(),
+	// but it was set to a lower value in the past due to a misunderstanding.
+	// The value is still high enough for practical purposes, so we don't want
+	// to change it now, avoiding confusion for importers of this variable.
+	maxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
+
+	minTimeFormatted = minTime.Format(time.RFC3339Nano)
+	maxTimeFormatted = maxTime.Format(time.RFC3339Nano)
+)
+
 // ParseTimestamp parses a timestamp from a string. The timestamp can be either
 // a unix epoch timestamp or RFC33339 format.
-func ParseTimestamp(ts string) (time.Time, error) {
-	// According to API docs:
-	//
-	// <rfc3339 | unix_timestamp>: Input timestamps may be provided either in
-	// RFC3339 format or as a Unix timestamp in seconds, with optional decimal
-	// places for sub-second precision. Output timestamps are always represented
-	// as Unix timestamps in seconds.
-	//
-	// https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview
-
-	// is it a unix timestamp?
-	if unixTs, err := strconv.ParseFloat(ts, 64); err == nil {
-		s, ns := math.Modf(unixTs)
-		t := time.Unix(int64(s), int64(ns*float64(time.Second)))
+//
+// Copied from Prometheus codebase:
+// https://github.com/prometheus/prometheus/blob/main/web/api/v1/api.go#L2082-L2103
+func ParseTimestamp(s string) (time.Time, error) {
+	if t, err := strconv.ParseFloat(s, 64); err == nil {
+		s, ns := math.Modf(t)
+		ns = math.Round(ns*1000) / 1000
+		return time.Unix(int64(s), int64(ns*float64(time.Second))).UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
 	}
 
-	// if not a unix timestamp, is it RFC3339?
-	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
-		return t, nil
+	// Stdlib's time parser can only handle 4 digit years. As a workaround until
+	// that is fixed we want to at least support our own boundary times.
+	// Context: https://github.com/prometheus/client_golang/issues/614
+	// Upstream issue: https://github.com/golang/go/issues/20555
+	switch s {
+	case minTimeFormatted:
+		return minTime, nil
+	case maxTimeFormatted:
+		return maxTime, nil
 	}
-
-	return time.Time{}, fmt.Errorf("failed to parse %s to timestamp", ts)
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
 }

--- a/pkg/prometheus/utils_test.go
+++ b/pkg/prometheus/utils_test.go
@@ -1,0 +1,62 @@
+package prometheus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimestamp(t *testing.T) {
+	testCases := []struct {
+		name          string
+		ts            string
+		expectedTime  time.Time
+		expectedError bool
+	}{
+		{
+			name:          "Unix Timestamp",
+			ts:            "1136214245",
+			expectedTime:  time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
+			expectedError: false,
+		},
+		{
+			name:          "Unix Timestamp with Fractional Seconds",
+			ts:            "1136214245.123",
+			expectedTime:  time.Date(2006, 1, 2, 15, 4, 5, 123000000, time.UTC),
+			expectedError: false,
+		},
+		{
+			name:          "RFC3339 Timestamp",
+			ts:            "2006-01-02T15:04:05Z",
+			expectedTime:  time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
+			expectedError: false,
+		},
+		{
+			name:          "RFC3339Nano Timestamp",
+			ts:            "2006-01-02T15:04:05.123Z",
+			expectedTime:  time.Date(2006, 1, 2, 15, 4, 5, 123000000, time.UTC),
+			expectedError: false,
+		},
+		{
+			name:          "Invalid Timestamp",
+			ts:            "invalid",
+			expectedTime:  time.Time{},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTimestamp(tc.ts)
+			switch tc.expectedError {
+			case true:
+				require.Error(t, err)
+			default:
+				require.NoError(t, err)
+			}
+
+			require.True(t, tc.expectedTime.Equal(got), "expected times to be equal", "expected", tc.expectedTime, "got", got)
+		})
+	}
+}


### PR DESCRIPTION
- **ref: decouple api creation, move http config loading to main**
- **ref: improve timestamp parsing**
- **test: add test for time parsing**
- **ref: remove global api client, load from tool middleware**
- **ref: make func to get client from context handle errors more gracefully**
- **test: add tests for api client creation handling**
- **test: add mock promv1 API for testing**
- **test: add test for query tool handler**
- **test: add test for range query tool handler**
- **test: add test snapshot tool handler**
- **test: add tests for delete series tool handler**
- **test: add tests for clean tombstones tool handler**
- **test: add tests for metric metadata tool handler**
- **test: add tests for target metadata tool handler**
- **test: add tests for list targets tool handler**
- **test: add tests for list rules tool handler**
- **test: add tests for runtime info tool handler**
- **test: add tests for config tool handler**
- **test: add tests for build info tool handler**
- **test: add tests for flag tool handler**
- **test: add tests for list alerts tool handler**
- **tests: add tests for label values tool handler**
- **test: add tests for series tool handler**
