### PR TITLE
fix: make root context cancellable, better cleanup stdio server

### DIFF
--- a/cmd/prometheus-mcp-server/main.go
+++ b/cmd/prometheus-mcp-server/main.go
@@ -104,7 +104,8 @@ func main() {
 		logger.Error("Failed to load HTTP config file, using default HTTP round tripper", "err", err)
 	}
 
-	ctx := context.Background()
+	ctx, rootCtxCancel := context.WithCancel(context.Background())
+	defer rootCtxCancel()
 	client, err := mcp.NewAPIClient(*flagPrometheusUrl, rt)
 	if err != nil {
 		logger.Error("Failed to create Prometheus client for MCP server", "err", err)
@@ -131,6 +132,7 @@ func main() {
 			},
 			func(err error) {
 				close(cancel)
+				rootCtxCancel()
 			},
 		)
 	}
@@ -155,6 +157,7 @@ func main() {
 					logger.Error("failed to close listeners/context timeout", "err", err)
 				}
 				close(cancel)
+				rootCtxCancel()
 			},
 		)
 	}
@@ -188,6 +191,7 @@ func main() {
 			},
 			func(err error) {
 				close(cancel)
+				rootCtxCancel()
 			},
 		)
 	}


### PR DESCRIPTION
The refactor to use oklog/run and more directly manage goroutines
brought lots of benefits, but I didn't notice it lacked a way to
properly close and cleanup when running directly in stdio mode.

When the mcp server is started with a tool like a cli code agent (crush,
gemini, claude, etc) or with other mcp-compatible tool software, the
binary for the mcp server is often invoked directly by the other tool.
Meaning that when that tool exits, the child process of the mcp server
gets cleaned up by the OS regardless. But when run directly at the shell
using stdio transport, a standard SIGINT/ctrl-c doesn't properly exit.
Instead, the signal is caught, all of the managed goroutines catch their
clean up calls and wrap up, but the stdio server never catches anything
to tell it to cleanup. This leaves it and it's associated background
processing goroutines hanging around. It was easy to observe in logs as
I could see the signal get caught and cleanup terminate, but further
ctrl-c's did nothing, and the server was obviously still running and
listening on stdin for input to process, as just hitting enter would
result in it spitting out a json RPC error about improperly formatted
requests. The same issue was _NOT_ present in the HTTP/SEE
implementations, because we're not using the libraries helper functions
to manage the webserver lifecycle, and instead and directly managing the
webserver ourselves for other purposes as well, such as metrics and
pprof, and so the mcp server gets registered as a handler, and the
server is cleaned up along with the rest of the webserver when the
goroutine managing the webserver is closed in the run group.

Changing the root context to have a cancel func provides a way to tell
the stdio server to exit. It functions like a sync.Once func where it's
safe to call concurrently and it only ever gets called once, all
subsequent calls are noops, meaning it's safe to immediately defer and
also call directly in the cleanup funcs for each of the run group
goroutines.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
