### PR TITLE
feat: add /docs API endpoint to serve static prometheus docs

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: actions/setup-go@v5
         with:
           go-version: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          submodules: recursive
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          submodules: recursive
       - run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmd/prometheus-mcp-server/external/docs"]
+	path = cmd/prometheus-mcp-server/external/docs
+	url = https://github.com/prometheus/docs.git

--- a/pkg/mcp/promapi.go
+++ b/pkg/mcp/promapi.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -53,16 +52,6 @@ func NewAPIClient(prometheusUrl string, rt http.RoundTripper) (promv1.API, error
 	client, err := mcpProm.NewAPIClient(prometheusUrl, rt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prometheus API client: %w", err)
-	}
-
-	return client, nil
-}
-
-func getApiClientFromContext(ctx context.Context) (promv1.API, error) {
-	client, ok := ctx.Value(apiClientKey{}).(promv1.API)
-	if !ok {
-		return nil, errors.New("failed to get prometheus API client from context")
-
 	}
 
 	return client, nil

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"embed"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -77,6 +78,15 @@ func newApiClientLoaderMiddleware(c promv1.API) *apiClientLoaderMiddleware {
 
 func addApiClientToContext(ctx context.Context, c promv1.API) context.Context {
 	return context.WithValue(ctx, apiClientKey{}, c)
+}
+
+func getApiClientFromContext(ctx context.Context) (promv1.API, error) {
+	client, ok := ctx.Value(apiClientKey{}).(promv1.API)
+	if !ok {
+		return nil, errors.New("failed to get prometheus API client from context")
+	}
+
+	return client, nil
 }
 
 func (m *apiClientLoaderMiddleware) ToolMiddleware(next server.ToolHandlerFunc) server.ToolHandlerFunc {


### PR DESCRIPTION
This is phase 1 of adding documentation to the MCP server.

This commit adds the prometheus/docs repo as a submodule. The docs
subfolder that contains the markdown docs files are then embedded into
the binary, and then the static docs are served under the `/docs` route
on the webserver. This also updates CI in release process to pull
submodules.

Phase 2 is to add a background goroutine to use go-git to periodically
(daily?) check for updates to docs repo and update the docs to serve.

Phase 3 is to make resources to wrap the docs API to serve docs.

Phase 4 is to potentially add new tools to interact with the docs
resources.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
