### PR TITLE
ci: disable goreleaser mod proxy

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,8 +17,7 @@ builds:
     binary: prometheus-mcp-server
     main: './cmd/prometheus-mcp-server'
 gomod:
-  proxy: true
-  mod: mod
+  proxy: false
 dockers:
   # build amd64 container image
   - image_templates:


### PR DESCRIPTION
Fixes issues in CI builds where goreleaser can't find the docs path for
embedding docs because the submodule isn't available. The go mod proxy
setting here loads deps from proxy for building, which means that VCS
info isn't available. Since the docs are in a submodule, this means they
aren't available in this build pattern. Worked fine locally because
snapshots bypass this anyway.

This does come at the "expense" of verifiable builds and embedded module
info in the binary, but we already embed VCS/build info in anyway, so I
think it's reasonable to disable, especially for sake of fixing builds
in CI.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
