### PR TITLE
ci: enable publishing to the MCP registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@ on:
       - 'v*'
 
 permissions:
+  id-token: write  # Required for OIDC authentication to publish to MCP registry
   contents: write
   packages: write
 
 jobs:
-  goreleaser:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,3 +46,24 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install MCP Publisher
+        run: |
+          git clone --quiet https://github.com/modelcontextprotocol/registry publisher-repo
+          cd publisher-repo && make publisher > /dev/null && cd ..
+          cp publisher-repo/bin/mcp-publisher . && chmod +x mcp-publisher
+      - name: Update server.json version
+        run: |
+          TAG_VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          sed -i "s/\${VERSION}/$TAG_VERSION/g" server.json
+          echo "Version: $TAG_VERSION"
+      - name: Validate MCP registry server configuration
+        run: |
+          python3 -m json.tool server.json > /dev/null && echo "Configuration valid" || exit 1
+      - name: Display final server.json
+        run: |
+          echo "Final server.json contents:"
+          cat server.json
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.tjhop/prometheus-mcp-server",
+  "mcpName": "io.github.tjhop/prometheus-mcp-server",
+  "description": "An API-complete MCP server to manage Prometheus-compatible backends via comprehensive tools.",
+  "repository": {
+    "url": "https://github.com/tjhop/prometheus-mcp-server",
+    "source": "github"
+  },
+  "version": "${VERSION}",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://ghcr.io",
+      "identifier": "tjhop/prometheus-mcp-server",
+      "version": "${VERSION}",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "run",
+          "description": "The runtime command to execute"
+        },
+        {
+          "type": "named",
+          "name": "-i",
+          "description": "Run container in interactive mode"
+        },
+        {
+          "type": "named",
+          "name": "--rm",
+          "description": "Automatically remove the container when it exits"
+        },
+        {
+          "type": "positional",
+          "valueHint": "image_name",
+          "value": "ghcr.io/tjhop/prometheus-mcp-server",
+          "description": "The container image to run"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "named",
+          "name": "--prometheus.url",
+          "description": "URL of the Prometheus instance to connect to",
+          "default": "http://127.0.0.1:9090",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I published the first release manually for the v0.7.0 tag. The templated
server.json and workflow updates are based heavily on
github-mcp-server's configs in particular.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
