### PR TITLE
ci: fix oss mcp registry publication, bump and update schema

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.tjhop/prometheus-mcp-server",
   "mcpName": "io.github.tjhop/prometheus-mcp-server",
   "description": "An API-complete MCP server to manage Prometheus-compatible backends via comprehensive tools.",
@@ -11,9 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
-      "identifier": "tjhop/prometheus-mcp-server",
-      "version": "${VERSION}",
+      "identifier": "ghcr.io/tjhop/prometheus-mcp-server:${VERSION}",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
I hand published 0.9.0 to workaround this, but this will fix CI for next
time.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
