### PR TITLE
feat: add `tsdb_blocks` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Please see [Flags](#command-line-flags) for more information on the available fl
 | `runtime_info` | Get Prometheus runtime information |
 | `series` | Finds series by label matchers |
 | `targets_metadata` | Returns metadata about metrics currently scraped by the target |
+| `tsdb_blocks` | Get the list of currently loaded TSDB blocks and their metadata |
 | `tsdb_stats` | Get usage and cardinality statistics from the TSDB |
 | `wal_replay_status` | Get current WAL replay status |
 
@@ -164,6 +165,7 @@ Qualifications and support criteria are still under consideration, please open a
 | [`thanos`](https://thanos.io/) | `list_stores` | add | Thanos provides an additional endpoint to list store API servers. |
 | [`thanos`](https://thanos.io/) | `reload` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
 | [`thanos`](https://thanos.io/) | `quit` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
+| [`thanos`](https://thanos.io/) | `tsdb_blocks` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
 
 ### Resources
 

--- a/pkg/mcp/prometheus_tools.go
+++ b/pkg/mcp/prometheus_tools.go
@@ -137,6 +137,10 @@ var (
 		mcp.WithDescription("Get usage and cardinality statistics from the TSDB"),
 	)
 
+	prometheusTsdbBlocksTool = mcp.NewTool("tsdb_blocks",
+		mcp.WithDescription("Get the list of currently loaded TSDB blocks and their metadata."),
+	)
+
 	prometheusListAlertsTool = mcp.NewTool("list_alerts",
 		mcp.WithDescription("List all active alerts"),
 	)
@@ -520,6 +524,14 @@ func prometheusTsdbStatsToolHandler(ctx context.Context, request mcp.CallToolReq
 	data, err := tsdbStatsApiCall(ctx)
 	if err != nil {
 		return mcp.NewToolResultError("failed making TSDB stats api call: " + err.Error()), nil
+	}
+	return mcp.NewToolResultText(data), nil
+}
+
+func prometheusTsdbBlocksToolHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	data, err := tsdbBlocksApiCall(ctx)
+	if err != nil {
+		return mcp.NewToolResultError("failed making TSDB blocks api call: " + err.Error()), nil
 	}
 	return mcp.NewToolResultText(data), nil
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -63,6 +63,7 @@ var (
 		"targets_metadata":  {Tool: prometheusTargetsMetadataTool, Handler: prometheusTargetsMetadataToolHandler},
 		"list_targets":      {Tool: prometheusTargetsTool, Handler: prometheusTargetsToolHandler},
 		"tsdb_stats":        {Tool: prometheusTsdbStatsTool, Handler: prometheusTsdbStatsToolHandler},
+		"tsdb_blocks":       {Tool: prometheusTsdbBlocksTool, Handler: prometheusTsdbBlocksToolHandler},
 		"wal_replay_status": {Tool: prometheusWalReplayTool, Handler: prometheusWalReplayToolHandler},
 		"healthy":           {Tool: prometheusHealthyTool, Handler: prometheusHealthyToolHandler},
 		"ready":             {Tool: prometheusReadyTool, Handler: prometheusReadyToolHandler},
@@ -83,6 +84,7 @@ var (
 	//    - wal_replay_status
 	//    - reload
 	//    - quit
+	//    - tsdb_blocks
 	thanosToolset = map[string]server.ServerTool{
 		"build_info":       {Tool: prometheusBuildinfoTool, Handler: prometheusBuildinfoToolHandler},
 		"clean_tombstones": {Tool: prometheusCleanTombstonesTool, Handler: prometheusCleanTombstonesToolHandler},


### PR DESCRIPTION
Feature was added in Prometheus v3.6.0, and I added support for it in
prometheus/client_golang#1896. I have a few fixes to that that need to
get into a PR, but the functionality hasn't made it's way into a release
yet, so not a huge rush anyway.

This stages the ground work for the `tsdb_blocks` tool and the follow-on
API client updates for recent API work.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
