### PR TITLE
ci(goreleaser): update mcp config for github subkey deprecation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,22 +73,21 @@ archives:
     - examples/*
     - packaging/systemd/prometheus-mcp-server.service
 mcp:
-  github:
-    name: "io.github.tjhop/{{.ProjectName}}"
-    title: "Prometheus MCP Server"
-    description: "An API-complete MCP server to manage Prometheus-compatible backends."
-    homepage: "{{.GitURL}}"
-    repository:
-      source: "github"
-      url: "{{.GitURL}}"
-    auth:
-      type: 'github{{- if isEnvSet "GITHUB_ACTIONS" }}-oidc{{ end -}}'
-      token: "{{ .Env.GITHUB_TOKEN }}"
-    packages:
-      - registry_type: oci
-        identifier: "ghcr.io/tjhop/{{.ProjectName}}:{{ .Version }}"
-        transport:
-          type: stdio
+  name: "io.github.tjhop/{{.ProjectName}}"
+  title: "Prometheus MCP Server"
+  description: "An API-complete MCP server to manage Prometheus-compatible backends."
+  homepage: "{{.GitURL}}"
+  repository:
+    source: "github"
+    url: "{{.GitURL}}"
+  auth:
+    type: 'github{{- if isEnvSet "GITHUB_ACTIONS" }}-oidc{{ end -}}'
+    token: "{{ .Env.GITHUB_TOKEN }}"
+  packages:
+    - registry_type: oci
+      identifier: "ghcr.io/tjhop/{{.ProjectName}}:{{ .Version }}"
+      transport:
+        type: stdio
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
```
~/go/src/github.com/tjhop/prometheus-mcp-server (main [  ]) -> goreleaser check
  • checking                                  path=.goreleaser.yaml
  • DEPRECATED: mcp.github should not be used anymore, check https://goreleaser.com/deprecations#mcpgithub for more info
  • .goreleaser.yaml                                 error=configuration is valid, but uses deprecated properties
  ⨯ check failed                                     error=1 out of 1 configuration file(s) have issues
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
