### PR TITLE
feat: gracefully handle endpoints not implemented yet

### DIFF
--- a/pkg/mcp/errors.go
+++ b/pkg/mcp/errors.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+// ErrEndpointNotSupported indicates that a Prometheus API endpoint returned
+// HTTP 404, which typically means the endpoint is not available on the running
+// version of Prometheus. This wraps the original error for unwrapping.
+type ErrEndpointNotSupported struct {
+	Endpoint   string
+	StatusCode int
+	Err        error
+}
+
+// Error returns a user-friendly message explaining the 404 and suggesting
+// version-related remediation.
+func (e *ErrEndpointNotSupported) Error() string {
+	return fmt.Sprintf(
+		"the API endpoint %q returned HTTP %d (%s) -- "+
+			"this endpoint may not be supported by your version of Prometheus. "+
+			"Consider upgrading Prometheus or using the build_info tool to check documentation for the running version.",
+		e.Endpoint,
+		e.StatusCode,
+		http.StatusText(e.StatusCode),
+	)
+}
+
+// Unwrap returns the underlying error for errors.Is/As compatibility.
+func (e *ErrEndpointNotSupported) Unwrap() error {
+	return e.Err
+}
+
+// isNotFoundError checks whether an error returned by the prometheus
+// client_golang API client represents an HTTP 404 Not Found response.
+//
+// client_golang returns *promv1.Error with Type=ErrClient and Msg containing
+// "client error: 404" for 4xx responses.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var promErr *promv1.Error
+	if !errors.As(err, &promErr) {
+		return false
+	}
+
+	return promErr.Type == promv1.ErrClient && strings.Contains(promErr.Msg, "404")
+}
+
+// wrapErrorIfNotFound wraps a 404 error from client_golang into
+// ErrEndpointNotSupported with the given endpoint path. Non-404 errors are
+// returned unchanged.
+func wrapErrorIfNotFound(err error, endpoint string) error {
+	if isNotFoundError(err) {
+		return &ErrEndpointNotSupported{
+			Endpoint:   endpoint,
+			StatusCode: http.StatusNotFound,
+			Err:        err,
+		}
+	}
+	return err
+}

--- a/pkg/mcp/errors_test.go
+++ b/pkg/mcp/errors_test.go
@@ -1,0 +1,143 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+		{
+			name: "promv1 ErrClient 404",
+			err: &promv1.Error{
+				Type: promv1.ErrClient,
+				Msg:  "client error: 404",
+			},
+			expected: true,
+		},
+		{
+			name: "promv1 ErrClient non-404",
+			err: &promv1.Error{
+				Type: promv1.ErrClient,
+				Msg:  "client error: 400",
+			},
+			expected: false,
+		},
+		{
+			name: "promv1 ErrServer",
+			err: &promv1.Error{
+				Type: promv1.ErrServer,
+				Msg:  "server error: 500",
+			},
+			expected: false,
+		},
+		{
+			name: "promv1 ErrBadResponse",
+			err: &promv1.Error{
+				Type: promv1.ErrBadResponse,
+				Msg:  "bad response code 404",
+			},
+			expected: false,
+		},
+		{
+			name: "wrapped promv1 ErrClient 404",
+			err: fmt.Errorf("outer: %w", &promv1.Error{
+				Type: promv1.ErrClient,
+				Msg:  "client error: 404",
+			}),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := isNotFoundError(tc.err)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestWrapNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wraps 404 error into ErrEndpointNotSupported", func(t *testing.T) {
+		t.Parallel()
+
+		origErr := &promv1.Error{
+			Type: promv1.ErrClient,
+			Msg:  "client error: 404",
+		}
+		endpoint := "/api/v1/status/tsdb/blocks"
+
+		wrapped := wrapErrorIfNotFound(origErr, endpoint)
+
+		var notSupported *ErrEndpointNotSupported
+		require.ErrorAs(t, wrapped, &notSupported)
+		require.Equal(t, endpoint, notSupported.Endpoint)
+		require.Equal(t, http.StatusNotFound, notSupported.StatusCode)
+		require.ErrorIs(t, wrapped, origErr)
+	})
+
+	t.Run("passes through non-404 error unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		origErr := &promv1.Error{
+			Type: promv1.ErrServer,
+			Msg:  "server error: 500",
+		}
+		endpoint := "/api/v1/status/tsdb/blocks"
+
+		wrapped := wrapErrorIfNotFound(origErr, endpoint)
+
+		require.Equal(t, origErr, wrapped)
+	})
+
+	t.Run("passes through generic error unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		origErr := errors.New("connection refused")
+		endpoint := "/api/v1/status/tsdb/blocks"
+
+		wrapped := wrapErrorIfNotFound(origErr, endpoint)
+
+		require.Equal(t, origErr, wrapped)
+	})
+}
+
+func TestErrEndpointNotSupportedError(t *testing.T) {
+	t.Parallel()
+
+	err := &ErrEndpointNotSupported{
+		Endpoint:   "/api/v1/status/tsdb/blocks",
+		StatusCode: http.StatusNotFound,
+	}
+
+	msg := err.Error()
+	require.Contains(t, msg, "/api/v1/status/tsdb/blocks")
+	require.Contains(t, msg, "404")
+	require.Contains(t, msg, "Not Found")
+	require.Contains(t, msg, "may not be supported by your version of Prometheus")
+	require.Contains(t, msg, "build_info")
+}

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -643,7 +643,7 @@ func (s *ServerContainer) queryAPICall(ctx context.Context, query string, ts tim
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to execute instant query: %w", err)
+		return "", fmt.Errorf("failed to execute instant query: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	resultString := result.String()
@@ -670,7 +670,7 @@ func (s *ServerContainer) rangeQueryAPICall(ctx context.Context, query string, s
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to execute range query: %w", err)
+		return "", fmt.Errorf("failed to execute range query: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	resultString := result.String()
@@ -697,7 +697,7 @@ func (s *ServerContainer) exemplarQueryAPICall(ctx context.Context, query string
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to execute exemplar query: %w", err)
+		return "", fmt.Errorf("failed to execute exemplar query: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	var resultSB strings.Builder
@@ -734,7 +734,7 @@ func (s *ServerContainer) seriesAPICall(ctx context.Context, matches []string, s
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get series: %w", err)
+		return "", fmt.Errorf("failed to get series: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	lsets := make([]string, len(result))
@@ -766,7 +766,7 @@ func (s *ServerContainer) labelNamesAPICall(ctx context.Context, matches []strin
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get label names: %w", err)
+		return "", fmt.Errorf("failed to get label names: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	resultString := strings.Join(result, "\n")
@@ -793,7 +793,7 @@ func (s *ServerContainer) labelValuesAPICall(ctx context.Context, label string, 
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get label values: %w", err)
+		return "", fmt.Errorf("failed to get label values: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	lvals := make([]string, len(result))
@@ -844,7 +844,7 @@ func (s *ServerContainer) metricMetadataAPICall(ctx context.Context, metric, lim
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get metric metadata from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get metric metadata from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	encodedData, err := s.FormatOutput(mm)
@@ -889,7 +889,7 @@ func (s *ServerContainer) targetsMetadataAPICall(ctx context.Context, matchTarge
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get target metadata from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get target metadata from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	encodedData, err := s.FormatOutput(tm)
@@ -915,7 +915,7 @@ func (s *ServerContainer) alertmanagersAPICall(ctx context.Context) (string, err
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get alertmanager status from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get alertmanager status from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(ams)
@@ -932,7 +932,7 @@ func (s *ServerContainer) flagsAPICall(ctx context.Context) (string, error) {
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get runtime flags from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get runtime flags from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(flags)
@@ -949,7 +949,7 @@ func (s *ServerContainer) listAlertsAPICall(ctx context.Context) (string, error)
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get alerts from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get alerts from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(alerts)
@@ -966,7 +966,7 @@ func (s *ServerContainer) tsdbStatsAPICall(ctx context.Context) (string, error) 
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get tsdb stats from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get tsdb stats from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(tsdbStats)
@@ -983,7 +983,7 @@ func (s *ServerContainer) buildinfoAPICall(ctx context.Context) (string, error) 
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get build info from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get build info from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(bi)
@@ -1000,7 +1000,7 @@ func (s *ServerContainer) configAPICall(ctx context.Context) (string, error) {
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get configuration from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get configuration from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(cfg)
@@ -1017,7 +1017,7 @@ func (s *ServerContainer) runtimeinfoAPICall(ctx context.Context) (string, error
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get runtime info from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get runtime info from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(ri)
@@ -1034,7 +1034,7 @@ func (s *ServerContainer) rulesAPICall(ctx context.Context) (string, error) {
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get rules from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get rules from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(rules)
@@ -1051,7 +1051,7 @@ func (s *ServerContainer) targetsAPICall(ctx context.Context) (string, error) {
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get targets from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get targets from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(targets)
@@ -1068,7 +1068,7 @@ func (s *ServerContainer) walReplayAPICall(ctx context.Context) (string, error) 
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to get WAL replay status from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to get WAL replay status from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(wal)
@@ -1085,7 +1085,7 @@ func (s *ServerContainer) cleanTombstonesAPICall(ctx context.Context) (string, e
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to clean tombstones from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to clean tombstones from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return "success", nil
@@ -1102,7 +1102,7 @@ func (s *ServerContainer) deleteSeriesAPICall(ctx context.Context, matches []str
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to delete series from Prometheus: %w", err)
+		return "", fmt.Errorf("failed to delete series from Prometheus: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return "success", nil
@@ -1119,7 +1119,7 @@ func (s *ServerContainer) snapshotAPICall(ctx context.Context, skipHead bool) (s
 	metricAPICallDuration.With(prometheus.Labels{"target_path": path}).Observe(time.Since(startTs).Seconds())
 	if err != nil {
 		metricAPICallsFailed.With(prometheus.Labels{"target_path": path}).Inc()
-		return "", fmt.Errorf("failed to create Prometheus snapshot: %w", err)
+		return "", fmt.Errorf("failed to create Prometheus snapshot: %w", wrapErrorIfNotFound(err, path))
 	}
 
 	return s.FormatOutput(ss)
@@ -1164,6 +1164,12 @@ func (s *ServerContainer) doHTTPRequest(ctx context.Context, method string, rt h
 	metricAPICallDuration.With(prometheus.Labels{"target_path": requestPath}).Observe(time.Since(startTs).Seconds())
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return "", &ErrEndpointNotSupported{
+				Endpoint:   requestPath,
+				StatusCode: resp.StatusCode,
+			}
+		}
 		return "", fmt.Errorf("received non-ok HTTP status code: %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
Addresses: #45
Relates to: #77

This wires up support for checking API/HTTP errors for 404s. Since all
API endpoints are known and static, we can assume that a 404 from an
endpoint means that it's not implemented. This is more expected on
third-party prometheus systems with varying levels of API support, but
this also helps for prometheus itself.

For instance, Prometheus 3.5 is an LTS release and expected to be around
and running for a while. However, prometheus 3.6 added a TSDB blocks API
endpoint to the API. We should expect this endpoint to fail on
prometheus versions <3.6+.

When a 404 is detected, we return a specifically formatted error with
more context and guidance on checking prometheus version with the
build_info tool.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
