### PR TITLE
fix(thanos): remove prom tsdb admin tools from toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,14 @@ Qualifications and support criteria are still under consideration, please open a
 | --- | --- | --- | --- |
 | `prometheus` | n/a | none | Standard prometheus tools. Functionally equivalent to `--mcp.tools="all"`. The default MCP server toolset. |
 | [`thanos`](https://thanos.io/) | `alertmanagers` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
+| [`thanos`](https://thanos.io/) | `clean_tombstones` | remove | Prometheus TSDB admin endpoint |
 | [`thanos`](https://thanos.io/) | `config` | remove | Thanos does not use a centralized config, so it doesn't implement the endpoint and the tool returns a `404`. |
-| [`thanos`](https://thanos.io/) | `wal_replay_status` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
+| [`thanos`](https://thanos.io/) | `delete_series` | remove | Prometheus TSDB admin endpoint |
 | [`thanos`](https://thanos.io/) | `list_stores` | add | Thanos provides an additional endpoint to list store API servers. |
-| [`thanos`](https://thanos.io/) | `reload` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
 | [`thanos`](https://thanos.io/) | `quit` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
+| [`thanos`](https://thanos.io/) | `reload` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
+| [`thanos`](https://thanos.io/) | `snapshot` | remove | Prometheus TSDB admin endpoint |
+| [`thanos`](https://thanos.io/) | `wal_replay_status` | remove | Thanos does not implement the endpoint and the tool returns a `404`. |
 
 ### Resources
 

--- a/pkg/mcp/registration.go
+++ b/pkg/mcp/registration.go
@@ -235,13 +235,16 @@ func initPrometheusToolset() {
 }
 
 // thanosRemovedTools lists tools from prometheusToolset that Thanos does not support.
-var thanosRemovedTools = []string{
-	"alertmanagers",
-	"config",
-	"wal_replay_status",
-	"reload",
-	"quit",
-}
+var thanosRemovedTools = append(
+	PrometheusTsdbAdminTools,
+	[]string{
+		"alertmanagers",
+		"config",
+		"wal_replay_status",
+		"reload",
+		"quit",
+	}...,
+)
 
 // initThanosToolset initializes the thanos toolset map. Called during
 // init to avoid initialization cycles and control initialization order.


### PR DESCRIPTION
The TSDB admin api endpoints are also prometheus specific and should be
added to the thanos removal list.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
