### PR TITLE
chore: add CODEOWNERS and MAINTAINERS.md files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+#
+# Please keep this file in sync with the MAINTAINERS.md file!
+#
+
+# Prometheus MCP maintainers are default code owners for the whole repo.
+* @prometheus/prometheus-mcp-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,7 @@
+# Maintainers
+
+## Please keep this file in sync with the CODEOWNERS file!
+
+* TJ Hoplock <t.hoplock@gmail.com> @tjhop
+* Matthias Loibl <mail@matthiasloibl.com> @metalmatze
+* Bartłomiej Płotka <bwplotka@gmail.com> @bwplotka


### PR DESCRIPTION
First step to enabling contributions, main is protected and PR reviews
are required, so github needs to know who to ping :upside_down_face:

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
