### PR TITLE
docs: rewrite AGENTS.md for accuracy and agent effectiveness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,55 +1,54 @@
 # Agent Guide for Prometheus MCP Server
 
-An MCP server that gives LLM clients typed tools and resources for working with a running Prometheus instance — PromQL queries, metric/series/label discovery, target and rule inspection, management endpoints, and gated TSDB-admin operations — plus custom tools and resources backed by an embedded, Bleve-indexed copy of the official Prometheus documentation. Compatible backends (e.g. Thanos) get tailored toolsets. See [README.md](README.md) for the full tool list, backend differences, install methods, auth, telemetry, and time-format handling.
+An MCP server that exposes a running Prometheus instance (or compatible backend, e.g. Thanos) to LLM clients as typed tools and resources, plus search over an embedded snapshot of the official Prometheus docs (Bleve-indexed at startup). [README.md](README.md) is the canonical reference for the tool list, install methods, auth, telemetry, and flags — when a change affects any of those, update the README rather than duplicating it here.
 
-## Development workflow
+## Build, test, lint
 
-Use `Makefile` targets — not raw `go` commands. The build uses the standard Prometheus tooling: [`promu`](https://github.com/prometheus/promu) driven through `Makefile` / `Makefile.common`. The embedded Prometheus documentation is a pinned `prometheus/docs` snapshot (`DOCS_VERSION` in the `Makefile`) that `make docs` downloads as a tarball and extracts into `cmd/prometheus-mcp/external/docs/`; `build`, `test`, and `crossbuild` depend on it, and the directory is gitignored.
+Standard Prometheus tooling: `Makefile` includes `Makefile.common` and drives [`promu`](https://github.com/prometheus/promu); CI is [`prometheus/promci`](https://github.com/prometheus/promci) (`.github/workflows/ci.yml`). Release artifacts are built in CI, not locally.
 
 | Task | Command |
 |---|---|
-| Run tests | `make test` |
-| Run linters | `make lint` |
-| Full check suite (style, license, lint, yamllint, tidy, build, test) | `make` |
-| Build the binary for the host | `make build` |
-| Cross-build all release platforms | `make crossbuild` |
-| Refresh the embedded docs snapshot | `make docs` |
-| List the project-specific targets | `make help` |
+| Tests | `make test` |
+| Single test while iterating | `go test -race -run TestName ./pkg/mcp/` |
+| Lint | `make lint` |
+| Full pre-commit check (style, license headers, lint, yamllint, tidy, build, test) | `make` |
+| Build host binary | `make build` |
+| Refresh embedded docs snapshot | `make docs` |
+| List project-specific targets | `make help` |
 
-Use bare `make` (or `make lint test` for a faster subset) as the default pre-commit check. Release artifacts (container images, tarballs) are produced in CI via [`prometheus/promci`](https://github.com/prometheus/promci) + `promu` — not built locally.
+Things CI enforces that are easy to miss locally:
 
-## Code layout (`pkg/mcp/`)
+- **The docs embed.** `cmd/prometheus-mcp/main.go` declares `//go:embed all:external/docs`, and that directory is *gitignored* — `make docs` populates it from a pinned `prometheus/docs` tarball (`DOCS_VERSION` in the `Makefile`). On a fresh clone, raw `go build ./...` / `go test ./...` fails with a "no matching files" embed error; run any make build/test target once and raw `go` commands work from then on (package-scoped commands like `go test ./pkg/mcp/` don't need the snapshot at all).
+- **License headers.** Every source file needs the Apache-2.0 header (`check_license` runs as part of bare `make`). Copy it from any existing `.go` file when creating a new one.
+- **No drift.** CI runs `make` and then `git diff --exit-code` — un-tidied `go.mod`/`go.sum` or anything else the build regenerates must be committed.
+- golangci-lint (version taken from `make print-golangci-lint-version`) and `govulncheck` also gate PRs.
+- The Go version is pinned in three places — `go.mod`, `.promu.yml`, and the builder image in `ci.yml`. Bump them together.
 
-- `server.go` — `ServerContainer` (DI struct), middleware chain, HTTP + stdio transport.
-- `tools.go` — `*mcp.Tool` definitions with annotations.
-- `types.go` — tool input structs (`jsonschema` tags) and their `slog.LogValuer` implementations.
-- `handlers.go` — tool handler methods on `*ServerContainer`.
-- `registration.go` — toolset composition, per-backend toolsets (prometheus, thanos), `CoreTools` list.
-- `resources.go` — MCP resources (metric list, targets, docs).
-- `docs.go`, `docs_updater.go` — Bleve-indexed doc search with optional live auto-update.
-- `middleware.go`, `errors.go`, `logging.go` — telemetry middleware, graceful 404 handling, MCP client logging.
+## Architecture in brief
 
-Supporting: `pkg/prometheus/` (API client builder, plus the `UserAgent()` helper), `internal/metrics/` (metrics registry + namespace). Build/version info comes from `github.com/prometheus/common/version` (populated by promu ldflags); the embedded docs commit is read from `external/docs/COMMIT_HASH` at startup in `cmd/prometheus-mcp/main.go`.
+- `cmd/prometheus-mcp/main.go` — kingpin flag definitions (every flag is also settable via an auto-generated env var, via `DefaultEnvars()`), transport selection (`--mcp.transport=stdio|http`; the stdio loop lives *here*, HTTP mounts `mcp.NewStreamableHTTPHandler` at `/mcp`), the docs `go:embed`, and the exporter-toolkit web server (metrics, pprof, landing page, embedded docs at `/docs/`). Version info comes from `prometheus/common/version`, populated by promu ldflags.
+- `pkg/mcp/` — the server proper. `ServerContainer` (`server.go`) is the DI struct every handler hangs off; tool definitions live in `tools.go`, input types in `types.go`, handlers in `handlers.go`, toolset composition in `registration.go`, MCP resources in `resources.go`, docs search in `docs.go`/`docs_updater.go`. The MCP instructions blob sent to clients is `pkg/mcp/assets/instructions.md`.
+- **Backend toolsets** derive from the base Prometheus toolset: each backend has a `<backend>RemovedTools` list and an `init<Backend>Toolset` initializer that prunes unsupported tools and adds backend-specific ones (`initThanosToolset` is the canonical example). To add a backend, extend `PrometheusBackends`, add the removal list + initializer, and wire it into `getToolset`'s switch — don't fork a parallel map. `CoreTools` always loads even when `--mcp.tools` narrows the set; `PrometheusTsdbAdminTools` is the destructive set gated behind `--dangerous.enable-tsdb-admin-tools`.
+- **Docs subsystem**: the Bleve index is built at startup from the embedded docs FS; `--docs.auto-update` swaps it at runtime, hence `docsMu sync.RWMutex` in `ServerContainer` — read under `RLock`, write under `Lock`.
+- Supporting: `pkg/prometheus/` (API client builder, `UserAgent()`, time parsing), `internal/metrics/` (metrics registry + namespace).
 
 ## Adding a new tool
 
 1. **Input type** in `types.go`: struct with `jsonschema` tags and a `LogValue() slog.Value` method so structured logs group fields cleanly. Reuse `TimeRangeInput`, `TruncatableInput` where applicable.
-2. **Tool definition** in `tools.go`: `*mcp.Tool` with `Annotations.ReadOnlyHint` *or* `Annotations.DestructiveHint` (use the `ptr(true)` helper — can't take the address of a constant). Zero-input tools use `InputSchema: emptyInputSchema`, not the SDK's `EmptyInput` — see issue [#119](https://github.com/tjhop/prometheus-mcp-server/issues/119) for the OpenAI strict-schema workaround.
-3. **Handler** method on `*ServerContainer` in `handlers.go`, signature `(ctx, req, input) (*mcp.CallToolResult, any, error)`. `s.GetAPIClient(ctx)` returns both the prom Go client *and* the matching `http.RoundTripper` — use the client for endpoints it supports, and route everything else through `s.doHTTPRequest` (see "HTTP plumbing" below). Never reach for the default client/transport fields directly; that bypasses request-scoped auth.
-4. **Register** in `initPrometheusToolset()` in `registration.go`. If Thanos doesn't support the tool, add its name to `thanosRemovedTools`. Leave `CoreTools` alone unless the tool is essential enough that it should still load even when a user explicitly narrows the toolset — the server already defaults to `--mcp.tools=all`.
-5. **Test** in `handlers_test.go` (mock Prometheus lives in `api_mock_test.go`). `registration_test.go` validates toolset composition — it will fail loudly if the maps are inconsistent.
+2. **Tool definition** in `tools.go`: `*mcp.Tool` with `Annotations.ReadOnlyHint` *or* `Annotations.DestructiveHint` (use the `ptr(true)` helper). Zero-input tools use `InputSchema: emptyInputSchema`, not the SDK's `EmptyInput` — OpenAI strict-schema workaround, see [#119](https://github.com/prometheus/prometheus-mcp/issues/119).
+3. **Handler** method on `*ServerContainer` in `handlers.go`, signature `(ctx, req, input) (*mcp.CallToolResult, any, error)`. Get clients via `s.GetAPIClient(ctx)` — see the HTTP plumbing gotcha below; never reach for default client/transport fields directly.
+4. **Register** in `initPrometheusToolset()` in `registration.go`; add the tool's name to `thanosRemovedTools` if Thanos doesn't support it. Leave `CoreTools` alone unless the tool must load even when `--mcp.tools` is narrowed.
+5. **Test** in `handlers_test.go`: `api_mock_test.go` has the mock Prometheus, and `mcptest.NewTestServer` provides an in-memory client↔server MCP session. `registration_test.go` pins expected toolset contents — update its expectations whenever tools are added or removed.
 6. Update the tool table in `README.md`.
 
-## Project-specific quirks/gotchas
+## Gotchas
 
-- **Time inputs** accept epoch seconds, RFC3339, *or* Go duration strings relative to now (`5m`, `1h30m`). Use `ParseTimestampOrDuration` / `parseTimeWithDefault` — don't hand-parse.
-- **HTTP plumbing.** `s.GetAPIClient(ctx)` returns both the prom Go client and the matching `http.RoundTripper`; `authContextMiddleware` makes the RoundTripper request-scoped when an `Authorization` header is present. For anything outside `promv1.API` — custom backends, management endpoints, new APIs — pull the RoundTripper and call `s.doHTTPRequest(ctx, method, rt, path, expectJSON)`, or `s.doManagementAPICall(ctx, method, path)` for `/-/...` endpoints. Both wrappers share the connection pool, emit `target_path`-labelled telemetry, and surface 404s as `ErrEndpointNotSupported`. References: `ThanosStoresHandler` for `/api/v1/...` calls, the Management API handlers for `/-/...`.
-- **Docs state** in `ServerContainer` is guarded by `sync.RWMutex` because `--docs.auto-update` can swap the Bleve index at runtime. Read under `RLock`, write under `Lock`.
-- **TSDB admin tools** (`delete_series`, `clean_tombstones`, `snapshot`) gate on the `--dangerous.enable-tsdb-admin-tools` flag and set `DestructiveHint`. `delete_series` additionally requires both `start_time` and `end_time` to avoid accidental full-data wipes.
-- **Metrics** register through `metrics.Registry` and use `metrics.MetricNamespace` via `prometheus.BuildFQName` — don't register globally.
-- **Backend toolsets** derive from the base Prometheus toolset: each backend has a `<backend>RemovedTools` list and an `init<Backend>Toolset` initializer that prunes unsupported tools and adds any backend-specific ones (see `initThanosToolset` for the canonical example). To add a new backend, extend `PrometheusBackends`, add the removal list + initializer, and wire it into `getToolset`'s switch — don't fork a parallel map.
-- **TOON output mode** is a server flag affecting how results are serialized to clients — not usually relevant when editing handler logic, but don't assume JSON shape in end-to-end tests.
+- **Time inputs** accept epoch seconds, RFC3339, *or* Go duration strings relative to now (`5m`, `1h30m`). Use `ParseTimestampOrDuration` (`pkg/prometheus`) / `parseTimeWithDefault` (`handlers.go`) — don't hand-parse.
+- **HTTP plumbing.** `s.GetAPIClient(ctx)` returns both the prom Go client *and* the matching `http.RoundTripper`; `authContextMiddleware` makes the RoundTripper request-scoped when an `Authorization` header is present, so going around it bypasses per-request auth. For anything outside `promv1.API`, call `s.doHTTPRequest(ctx, method, rt, path, expectJSON)`, or `s.doManagementAPICall(ctx, method, path)` for `/-/...` endpoints — both share the connection pool, emit `target_path`-labelled telemetry, and surface 404s as `ErrEndpointNotSupported`. Reference implementations: `ThanosStoresHandler` (`/api/v1/...`), the management API handlers (`/-/...`).
+- **TSDB admin tools** (`PrometheusTsdbAdminTools`) set `DestructiveHint` and only register when `--dangerous.enable-tsdb-admin-tools` is set; `delete_series` additionally requires both `start_time` and `end_time` to prevent accidental full-data deletion. Preserve both properties when touching these handlers.
+- **Metrics** register through `metrics.Registry` with `prometheus.BuildFQName(metrics.MetricNamespace, ...)` — never the global registry.
+- **`--mcp.enable-toon-output`** serializes tool results as TOON instead of JSON — don't hard-code JSON shape assumptions in end-to-end tests.
 
-## Testing
+## Helm chart
 
-`*_test.go` files sit alongside the code they test. `handlers_test.go` is where most new tool tests land; use `api_mock_test.go`'s mock Prometheus. Run `make test` often — it's fast.
+`charts/prometheus-mcp-server` has its own CI (`.github/workflows/helm-chart.yaml`, chart-testing) that runs only when `charts/**` or `grafana/**` change; check locally with `make helm-lint` / `make helm-template`. `charts/prometheus-mcp-server/dashboards/` is generated and gitignored — the dashboard source of truth is `grafana/*.json`, synced in by `make helm-sync-dashboards`.


### PR DESCRIPTION
I had claude re-review and optimize the AGENTS.md config now that we
fully cutover build system/CI to prometheus tooling. Here's what it did:

---

Fact-checked every claim against tip of main (post promu/promci
migration) and rewrote the guide to focus on what an agent cannot
discover from the tree itself:

- Fix stale claims: stdio transport lives in cmd/prometheus-mcp/main.go
  (not server.go), issue #119 link now points at the prometheus org, the
  Bleve index is built at startup rather than embedded, and
  registration_test.go pins hardcoded expectations (update them when
  adding tools) rather than generically validating map consistency.
- Replace the pkg/mcp file-by-file inventory (discoverable via ls, and
  the section that had already drifted) with an architecture narrative
  that only carries non-obvious information.
- Document the CI gates that are easy to miss locally: Apache license
  headers on every file, `make` followed by `git diff --exit-code`,
  golangci-lint version pinning, govulncheck, and the gitignored
  go:embed docs directory that `make docs` must populate before raw
  `go build ./...` / `go test ./...` can work.
- Add previously missing content: single-test invocation, the
  mcptest.NewTestServer in-memory harness, kingpin DefaultEnvars
  (flags double as env vars), the three-way Go version pin, and the
  helm chart's generated dashboards + chart-testing CI.
- Structure the build/test/lint section as Prometheus-org-generic so it
  could later be lifted into a shared org-level agent guide.

Assisted-by: Claude Code:claude-fable-5 <noreply@anthropic.com>
Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
