### PR TITLE
fix(ci): restore docs snapshot step, yamllint overrides

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,8 @@
 ---
-# This action is synced from https://github.com/prometheus/prometheus
+# Originally synced from https://github.com/prometheus/prometheus, but this
+# copy carries a repo-specific step (the embedded docs snapshot must exist
+# before the linter can typecheck the go:embed directive), so it is
+# excluded from repo_sync: no_prometheus_repo_sync
 name: golangci-lint
 on:
   push:
@@ -33,9 +36,10 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.x
-      - name: Install snmp_exporter/generator dependencies
-        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
-        if: github.repository == 'prometheus/snmp_exporter'
+      - name: Download embedded docs snapshot
+        # The binary embeds the prometheus/docs snapshot via go:embed; the linter
+        # compiles the packages, so it must be present.
+        run: make docs
       - name: Get golangci-lint version
         id: golangci-lint-version
         run: echo "version=$(make print-golangci-lint-version)" >> $GITHUB_OUTPUT

--- a/.yamllint
+++ b/.yamllint
@@ -1,8 +1,11 @@
 ---
+# Customized for this repo (Helm chart templates and the embedded docs
+# snapshot are not lintable YAML); excluded from repo_sync: no_prometheus_repo_sync
 extends: default
 ignore: |
   **/node_modules
-  web/api/v1/testdata/openapi_*_golden.yaml
+  cmd/prometheus-mcp/external/docs/
+  charts/
 
 rules:
   braces:
@@ -18,9 +21,7 @@ rules:
   indentation:
     spaces: consistent
     indent-sequences: consistent
-  key-duplicates:
-    ignore: |
-      config/testdata/section_key_dup.bad.yml
+  key-duplicates: {}
   line-length: disable
   truthy:
     check-keys: false


### PR DESCRIPTION
The repo_sync automation (https://github.com/prometheus/prometheus-mcp/pull/152) replaced this workflow with the stock
copy from prometheus/prometheus, dropping the "Download embedded docs
snapshot" step added in the switch to promci tooling in https://github.com/prometheus/prometheus-mcp/pull/145. Without
`make docs`, the gitignored `cmd/prometheus-mcp/external/docs` directory
is empty and golangci-lint's typecheck fails on the `go:embed
all:external/docs` directive, breaking lint on main and every PR since.

Restore the step and mark the file with `no_prometheus_repo_sync`. Also
restores the ignores, drop the prometheus/prometheus-specific testdata
entries that reference files this repo does not have, and mark the file
with `no_prometheus_repo_sync` so the sync script skips it as well.

On the bright side, the helm stuff is only temporary as we work to move
the chart publishing for the mcp server into
prometheus-community/helm-charts

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>