### PR TITLE
ci: re-add MCP registration validation label and publication job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,35 @@ jobs:
           ghcr_io_password: ${{ github.token }}
           quay_io_password: ${{ secrets.quay_io_password }}
           github_token: ${{ github.token }}
+
+  publish_mcp_registry:
+    name: Publish to MCP registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # OIDC auth to the MCP registry (io.github.prometheus/* namespace)
+    # The registry validates the OCI package by pulling the image and checking
+    # its io.modelcontextprotocol.server.name label, so the release images must
+    # already be pushed.
+    needs: [publish_release]
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install mcp-publisher
+        # Pinned publisher CLI release from https://github.com/modelcontextprotocol/registry/releases
+        run: curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+      - name: Render server.json version
+        # promci pushes release images tagged with the raw (v-prefixed) git
+        # tag; the registry version is the bare semver, so server.json
+        # references the image as v${VERSION}.
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          sed -i "s/\${VERSION}/${version}/g" server.json
+          python3 -m json.tool server.json
+      - name: Publish to MCP registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ ARG ARCH="amd64"
 ARG OS="linux"
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+# MCP registry ownership label. Must stay in sync with `name` in server.json.
+LABEL io.modelcontextprotocol.server.name="io.github.prometheus/prometheus-mcp"
 
 ARG ARCH="amd64"
 ARG OS="linux"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.prometheus/prometheus-mcp",
+  "description": "An API-complete MCP server to manage Prometheus-compatible backends.",
+  "title": "Prometheus MCP Server",
+  "repository": {
+    "url": "https://github.com/prometheus/prometheus-mcp",
+    "source": "github"
+  },
+  "version": "${VERSION}",
+  "websiteUrl": "https://github.com/prometheus/prometheus-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/prom/prometheus-mcp:v${VERSION}",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Docker image labels and MCP publication were previously handled by
goreleaser. Now that we're on prom build tooling, we need to re-add the
validation label and manually configure a CI job to publish.

For the label, the official MCP registry requires a validation label
that matches the `name` in server.json for OCI packages, needed to
re-enable publishing. Added via Dockerfile to not interfere with shared
Makefile/build commands.

For CI, this restores the standalone MCP publication job I used prior to
goreleaser adding MCP publication support, with a few
updates/modernizations:
- repo/org updated to reflect transfer to prometheus org
- update schema to latest
- update env vars to reflect project renaming
- switch publish job to pulling a pinned release binary instead of
  cloning/building like was needing way back when

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>