### PR TITLE
feat: migrate HTTP transport to stateless mode, upgrade go-sdk to v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ docker run --rm -i -e PROMETHEUS_MCP_SERVER_PROMETHEUS_URL="https://$yourPrometh
 ```
 
 ```shell
-# Streamable HTTP transport (capable of SSE as well)
+# Stateless HTTP transport (application/json request/response)
 docker run --rm -p 8080:8080 ghcr.io/tjhop/prometheus-mcp-server:latest --prometheus.url "https://$yourPrometheus:9090" --mcp.transport "http" --web.listen-address ":8080"
 
 # or using env vars

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -134,13 +134,8 @@ var (
 		"mcp.keepalive-interval",
 		"Interval for sending keepalive pings to connected MCP sessions."+
 			" If the peer fails to respond, the session is closed."+
-			" Most useful for HTTP transports to prevent idle connections from dropping.",
+			" Most useful for stdio transport to prevent idle connections from dropping.",
 	).Default("30s").Duration()
-
-	flagMcpSessionTimeout = kingpin.Flag(
-		"mcp.session-timeout",
-		"Idle session timeout for HTTP transport MCP sessions.",
-	).Default("10m").Duration()
 
 	flagDocsAutoUpdate = kingpin.Flag(
 		"docs.auto-update",
@@ -296,7 +291,7 @@ func main() {
 				case "http":
 					logger.Debug("starting MCP server", "transport", "http")
 
-					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger, *flagMcpSessionTimeout)
+					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger)
 					http.Handle("/mcp", httpMcpHandler)
 					<-cancel
 				default:
@@ -355,15 +350,11 @@ func main() {
 func initHTTPServer(logger *slog.Logger) *http.Server {
 	server := &http.Server{
 		// These are TCP-level timeouts for individual HTTP
-		// request/response cycles, not MCP session timeouts.  MCP
-		// sessions are long lived, tracked by session ID, and managed
-		// through the go-sdk separately from these HTTP server values.
-		//
-		// Important: Because SSE/HTTP transports are streams, the
-		// WriteTimeout must be disabled because the response "never
-		// finishes".
+		// request/response cycles. Stateless HTTP transport uses
+		// application/json responses that complete in a single round
+		// trip, so standard timeouts apply.
 		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 0,
+		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,
 	}
 

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -354,7 +354,7 @@ func initHTTPServer(logger *slog.Logger) *http.Server {
 		// application/json responses that complete in a single round
 		// trip, so standard timeouts apply.
 		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		WriteTimeout: *flagPrometheusTimeout,
 		IdleTimeout:  30 * time.Second,
 	}
 

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -130,13 +130,6 @@ var (
 			" Docs: https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis",
 	).Default("false").Bool()
 
-	flagMcpKeepaliveInterval = kingpin.Flag(
-		"mcp.keepalive-interval",
-		"Interval for sending keepalive pings to connected MCP sessions."+
-			" If the peer fails to respond, the session is closed."+
-			" Most useful for stdio transport to prevent idle connections from dropping.",
-	).Default("30s").Duration()
-
 	flagDocsAutoUpdate = kingpin.Flag(
 		"docs.auto-update",
 		"Enable automatic documentation updates from the official prometheus/docs repository."+
@@ -214,7 +207,6 @@ func main() {
 		DocsFS:                docsFs,
 		ToonOutputEnabled:     *flagMcpToonOutputEnabled,
 		ClientLoggingEnabled:  *flagMcpClientLogging,
-		KeepAlive:             *flagMcpKeepaliveInterval,
 	})
 	if err != nil {
 		logger.Error("Failed to create MCP server", "err", err)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alpkeskin/gotoon v0.1.1
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/go-git/go-git/v5 v5.19.1
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oklog/run v1.2.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/mdlayher/socket v0.6.1 h1:M7uj2NtuujUY4mYr1C57NmfNiRHbkKpnBxO856lsc3A
 github.com/mdlayher/socket v0.6.1/go.mod h1:+/SGtqc9V+5dAuRgQsU0fGBI+oRDiW7O2Obx10OIWfg=
 github.com/mdlayher/vsock v1.3.0 h1:bqQfZ1OznI03y6YiXp2sze05RVdzLn/zsfjnjd4+ivI=
 github.com/mdlayher/vsock v1.3.0/go.mod h1:WsuksavOvwCnV5UqGHUkvAvCy+Dqy81y4goKQTzxxNY=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -229,22 +229,20 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*mcp.Server, *ServerConta
 	return server, container, nil
 }
 
-// NewStreamableHTTPHandler creates an HTTP handler for the MCP server.
+// NewStreamableHTTPHandler creates an HTTP handler for the MCP server using
+// stateless HTTP transport. In stateless mode, each request is handled
+// independently without session tracking, and responses are returned as
+// application/json rather than text/event-stream.
 // It wraps the handler with auth context middleware to forward Authorization headers.
-func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTimeout time.Duration) http.Handler {
-	if sessionTimeout == 0 {
-		// 0 value for session timeout means that sessions never close.
-		// Set a default if unset.
-		sessionTimeout = 1 * time.Hour
-	}
-
+func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger) http.Handler {
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server {
 			return server
 		},
 		&mcp.StreamableHTTPOptions{
-			SessionTimeout: sessionTimeout,
-			Logger:         logger,
+			Stateless:    true,
+			JSONResponse: true,
+			Logger:       logger,
 		},
 	)
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -156,7 +156,6 @@ type ServerConfig struct {
 	DocsFS                fs.FS
 	ToonOutputEnabled     bool
 	ClientLoggingEnabled  bool
-	KeepAlive             time.Duration
 }
 
 // NewServer creates a new MCP server using the official Go SDK.
@@ -204,7 +203,6 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*mcp.Server, *ServerConta
 		&mcp.ServerOptions{
 			Instructions: instrx,
 			Logger:       logger.WithGroup("go_sdk_logger"),
-			KeepAlive:    cfg.KeepAlive,
 			Capabilities: caps,
 		},
 	)


### PR DESCRIPTION
Switches the HTTP MCP transport from stateful (SSE, session-tracked) to stateless mode: each request is an independent JSON round-trip with no session ID validation or server-initiated messages.

## Changes

- **`go-sdk` v1.6.1 → v1.7.0** — `Stateless` field on `StreamableHTTPOptions` was introduced in v1.7.0
- **`NewStreamableHTTPHandler`** — sets `Stateless: true` and `JSONResponse: true`; drops the `sessionTimeout`  and `KeepAlive` parameters (inapplicable in stateless mode)
- **`--mcp.session-timeout` flag removed** — sessions no longer exist; flag would be a no-op
- **`WriteTimeout` matches prometheus timeout** — previously forced to `0` to accommodate never-finishing SSE streams; stateless JSON responses complete within a single round trip
- **`--mcp.keepalive-interval` flag removed** — network connection is no longer streamable, flag would be a no-op