### PR TITLE
feat: add --mcp.stateless for load-balanced HTTP deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,15 @@ Flags:
       --mcp.transport="stdio"    The type of transport to use for
                                  the MCP server [`stdio`, `http`].
                                  ($PROMETHEUS_MCP_SERVER_MCP_TRANSPORT)
+      --[no-]mcp.stateless       Run the HTTP transport in stateless mode:
+                                 the Mcp-Session-Id header is not validated
+                                 and every request is served with a temporary
+                                 session, so any replica behind a load balancer
+                                 can serve any request without session affinity.
+                                 Server-initiated requests to clients are
+                                 unavailable in this mode; consider disabling
+                                 --mcp.keepalive-interval alongside (set to 0).
+                                 ($PROMETHEUS_MCP_MCP_STATELESS)
       --prometheus.backend=PROMETHEUS.BACKEND  
                                  Customize the toolset for a specific
                                  Prometheus API compatible backend.

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -142,6 +142,15 @@ var (
 		"Idle session timeout for HTTP transport MCP sessions.",
 	).Default("10m").Duration()
 
+	flagMcpStateless = kingpin.Flag(
+		"mcp.stateless",
+		"Run the HTTP transport in stateless mode: the Mcp-Session-Id header is not"+
+			" validated and every request is served with a temporary session, so any"+
+			" replica behind a load balancer can serve any request without session"+
+			" affinity. Server-initiated requests to clients are unavailable in this"+
+			" mode; consider disabling --mcp.keepalive-interval alongside (set to 0).",
+	).Default("false").Bool()
+
 	flagDocsAutoUpdate = kingpin.Flag(
 		"docs.auto-update",
 		"Enable automatic documentation updates from the official prometheus/docs repository."+
@@ -296,7 +305,7 @@ func main() {
 				case "http":
 					logger.Debug("starting MCP server", "transport", "http")
 
-					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger, *flagMcpSessionTimeout)
+					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger, *flagMcpSessionTimeout, *flagMcpStateless)
 					http.Handle("/mcp", httpMcpHandler)
 					<-cancel
 				default:

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -231,7 +231,12 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*mcp.Server, *ServerConta
 
 // NewStreamableHTTPHandler creates an HTTP handler for the MCP server.
 // It wraps the handler with auth context middleware to forward Authorization headers.
-func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTimeout time.Duration) http.Handler {
+//
+// When stateless is true, the handler runs in the SDK's stateless mode: the
+// Mcp-Session-Id header is not validated and every request is served with a
+// temporary session, so any replica behind a load balancer can serve any
+// request — no session affinity required.
+func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTimeout time.Duration, stateless bool) http.Handler {
 	if sessionTimeout == 0 {
 		// 0 value for session timeout means that sessions never close.
 		// Set a default if unset.
@@ -244,6 +249,7 @@ func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTi
 		},
 		&mcp.StreamableHTTPOptions{
 			SessionTimeout: sessionTimeout,
+			Stateless:      stateless,
 			Logger:         logger,
 		},
 	)

--- a/pkg/mcp/stateless_test.go
+++ b/pkg/mcp/stateless_test.go
@@ -1,0 +1,103 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newStatelessTestHandler builds a real MCP server and wraps it in the
+// streamable HTTP handler under test.
+func newStatelessTestHandler(t *testing.T, stateless bool) http.Handler {
+	t.Helper()
+
+	logger, _ := newTestLogger()
+	server, _, err := NewServer(context.Background(), ServerConfig{
+		Logger:        logger,
+		PrometheusURL: "http://127.0.0.1:9090",
+	})
+	require.NoError(t, err)
+
+	return NewStreamableHTTPHandler(server, logger, time.Minute, stateless)
+}
+
+func postJSONRPC(t *testing.T, url, body, sessionID string) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestStreamableHTTPHandler_Stateless verifies that stateless mode serves
+// requests without any session establishment — the property that lets
+// load-balanced replicas serve any request — while stateful mode (the
+// default) rejects a tool call that skips session initialization.
+func TestStreamableHTTPHandler_Stateless(t *testing.T) {
+	t.Parallel()
+
+	toolsList := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+
+	t.Run("stateless serves tools/list without a session", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(newStatelessTestHandler(t, true))
+		defer ts.Close()
+
+		resp := postJSONRPC(t, ts.URL, toolsList, "")
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("stateful rejects unknown session ids", func(t *testing.T) {
+		t.Parallel()
+
+		// The load-balanced failure mode this feature exists to fix: a
+		// session id minted by one replica is unknown to another and the
+		// request is rejected in stateful mode.
+		ts := httptest.NewServer(newStatelessTestHandler(t, false))
+		defer ts.Close()
+
+		resp := postJSONRPC(t, ts.URL, toolsList, "SESSIONFROMANOTHERREPLICA")
+		defer resp.Body.Close()
+		require.NotEqual(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("stateless ignores unknown session ids", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(newStatelessTestHandler(t, true))
+		defer ts.Close()
+
+		// A session id minted by a different replica must not be rejected.
+		resp := postJSONRPC(t, ts.URL, toolsList, "SESSIONFROMANOTHERREPLICA")
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
## What

Adds a `--mcp.stateless` flag (default `false`, no behavior change) that runs the HTTP transport in the Go SDK's stateless mode (`StreamableHTTPOptions.Stateless`): the `Mcp-Session-Id` header is not validated and every request is served with a temporary session.

## Why

MCP streamable-HTTP sessions are held in server memory, so running multiple replicas behind a load balancer breaks sessions: a session created on one replica is unknown to the others, and requests routed across replicas fail with session-not-found (in practice: one tool call succeeds, the next dies seconds later, and clients must re-initialize). The SDK already implements the intended fix for replicated servers — stateless operation — but this server never exposes it.

Hit in production running 3 replicas of this server behind a gateway (Kubernetes, plain ClusterIP round-robin). With `--mcp.stateless` any replica serves any request and no session-affinity machinery is needed. Session-affinity alternatives don't really work here: hashing on `Mcp-Session-Id` can't route the *create* request (which carries no session id) to the same pod that later requests hash to.

## How

- `NewStreamableHTTPHandler` gains a `stateless bool` parameter wired into `StreamableHTTPOptions.Stateless`.
- Flag help notes that server-initiated requests to clients are unavailable in this mode and suggests disabling `--mcp.keepalive-interval` alongside.
- README: flag added to the help block.

## Testing

New `TestStreamableHTTPHandler_Stateless` exercises the load-balancing property directly against a real handler: a tool call carrying a session id minted elsewhere succeeds in stateless mode and is rejected in stateful mode; a call with no session id succeeds statelessly. Full `go test ./...` passes.

Related: #170 (per-request header forwarding) — together they make replicated, multi-tenant deployments of this server work behind a standard load balancer.